### PR TITLE
feat: enhance grid-pattern css util cy-60

### DIFF
--- a/apps/frontend/src/assets/css/utilities/grid-pattern.css
+++ b/apps/frontend/src/assets/css/utilities/grid-pattern.css
@@ -1,16 +1,22 @@
 .grid-pattern {
-	--grid-color: var(--color-grid-line-cream);
+	--grid-color: var(--color-text-secondary, #f6f5fa);
+	--grid-opacity: 1;
 	--grid-size: 8px;
 	--grid-line: 1.4px;
+	--color: color-mix(
+		in srgb,
+		var(--grid-color) calc(var(--grid-opacity) * 100%),
+		transparent
+	);
 
 	background-image:
 		linear-gradient(
-			var(--grid-color) var(--grid-line),
+			var(--color) var(--grid-line),
 			transparent var(--grid-line)
 		),
 		linear-gradient(
 			90deg,
-			var(--grid-color) var(--grid-line),
+			var(--color) var(--grid-line),
 			transparent var(--grid-line)
 		);
 	background-size: var(--grid-size) var(--grid-size);

--- a/apps/frontend/src/pages/auth/components/sign-in-form/styles.module.css
+++ b/apps/frontend/src/pages/auth/components/sign-in-form/styles.module.css
@@ -12,6 +12,7 @@
 
 .sign-in {
 	--grid-color: var(--color-grid-line-cream);
+	--grid-opacity: 0.8;
 
 	position: relative;
 	z-index: 200;

--- a/apps/frontend/src/pages/auth/components/sign-in-form/styles.module.css
+++ b/apps/frontend/src/pages/auth/components/sign-in-form/styles.module.css
@@ -1,4 +1,6 @@
 .container {
+	--grid-color: var(--color-grid-line-cream);
+
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -9,6 +11,8 @@
 }
 
 .sign-in {
+	--grid-color: var(--color-grid-line-cream);
+
 	position: relative;
 	z-index: 200;
 	width: 100%;

--- a/apps/frontend/src/pages/home/home.tsx
+++ b/apps/frontend/src/pages/home/home.tsx
@@ -8,7 +8,10 @@ const Home: React.FC = () => {
 		<>
 			<Header />
 			<main>
-				<section className={styles["hero__section"]} data-section-variant>
+				<section
+					className={getClassNames(styles["hero__section"], "grid-pattern")}
+					data-section-variant
+				>
 					<div
 						className={getClassNames(
 							styles["hero__content"],
@@ -28,7 +31,7 @@ const Home: React.FC = () => {
 						<button className={styles["hero__button-start"]}>Start</button>
 					</div>
 				</section>
-				<section data-section-variant="brand">
+				<section className="grid-pattern" data-section-variant="brand">
 					<div className="wrapper">
 						<h2>How it works</h2>
 					</div>
@@ -38,7 +41,7 @@ const Home: React.FC = () => {
 						<h2>Categories</h2>
 					</div>
 				</section>
-				<section data-section-variant="dark">
+				<section className="grid-pattern" data-section-variant="dark">
 					<div className="wrapper">
 						<h2>Sample visual layouts</h2>
 					</div>

--- a/apps/frontend/src/pages/home/styles.module.css
+++ b/apps/frontend/src/pages/home/styles.module.css
@@ -3,12 +3,22 @@ section[data-section-variant] {
 }
 
 section[data-section-variant="dark"] {
+	--grid-color: var(--color-text-primary);
+	--grid-opacity: 0.4;
+
 	color: var(--color-bg);
 	background-color: var(--color-bg-dark);
 }
 
 section[data-section-variant="brand"] {
+	--grid-color: var(--color-brand-primary);
+	--grid-opacity: 0.5;
+
 	background-color: var(--color-card-blue);
+}
+
+.hero__section {
+	--grid-color: var(--color-card-gray);
 }
 
 .hero__content {


### PR DESCRIPTION
This feature below has already been merged [here](https://github.com/BinaryStudioAcademy/bsa-2025-checkly/pull/59), but in this PR I suggest enhancing it a little - add opacity control for more flexible grid variations.

```css
section[data-section-variant="brand"] {
	--grid-color: var(--color-brand-primary);
	--grid-opacity: 0.5;

	background-color: var(--color-card-blue);
}
```



<img width="1916" height="915" alt="image" src="https://github.com/user-attachments/assets/99eabde0-8569-47d3-ad5d-7fbe480cd562" />
