### PR TITLE
fix: update body font family cy-76

### DIFF
--- a/apps/frontend/src/assets/css/scaffolding.css
+++ b/apps/frontend/src/assets/css/scaffolding.css
@@ -4,7 +4,7 @@ body {
 	min-width: 320px;
 	min-height: 100vh;
 	margin: 0;
-	font-family: var(--font-primary);
+	font-family: var(--font-family-primary);
 	font-size: var(--text-body);
 	font-weight: var(--font-weight-body);
 	line-height: var(--leading);


### PR DESCRIPTION
Hello!

In scaffolding.css, there's an incorrect css var value used to set body font-family.

```css
body {
    ...
	font-family: var(--font-primary); // s/b --font-family-primary
    ...
}
```