### PR TITLE
fix: whitelist to allow public access to api documentation cy-80

### DIFF
--- a/apps/backend/src/libs/modules/server-application/base-server-application.ts
+++ b/apps/backend/src/libs/modules/server-application/base-server-application.ts
@@ -147,9 +147,15 @@ class BaseServerApplication implements ServerApplication {
 	}
 
 	private getWhiteRoutes(): string[] {
-		return this.apis.flatMap((api) =>
+		const publicApiRoutes = this.apis.flatMap((api) =>
 			api.routes.filter((route) => route.isPublic).map((route) => route.path),
 		);
+
+		const documentationRoutes = this.apis.map(
+			(api) => `/${api.version}/documentation/**`,
+		);
+
+		return [...publicApiRoutes, ...documentationRoutes];
 	}
 
 	private initErrorHandler(): void {


### PR DESCRIPTION
By default, the route protection plugin defines all routes as private unless a route is explicitly set to be public.

When creating a route, a developer can define it as public. However, in the case of the documentation generated by Swagger, this is not possible, which causes the plugin to treat all of these documentation routes as private as well.

Therefore, the plugin correctly identifies all documentation routes as private.

To solve this, I modified the getWhiteRoutes method, which is responsible for identifying if a route is public, to include the documentation's route pattern as public.