### PR TITLE
fix: remove redundant css values cy-84

### DIFF
--- a/apps/frontend/src/assets/css/utilities/wrapper.css
+++ b/apps/frontend/src/assets/css/utilities/wrapper.css
@@ -1,12 +1,12 @@
 .wrapper {
 	max-width: var(--wrapper-max-width, 1064px);
-	padding-right: var(--space-gutter-m);
-	padding-left: var(--space-gutter-m);
+	padding-right: var(--space-m);
+	padding-left: var(--space-m);
 	margin-inline: auto;
 }
 
 .wrapper[data-wrapper-type="inner"] {
 	min-width: 100%;
-	padding-block: var(--gutter-wrapper-inner-block, var(--space-gutter-m));
-	padding-inline: var(--gutter-wrapper-inner-inline, var(--space-gutter-m));
+	padding-block: var(--gutter-wrapper-inner-block, var(--space-m));
+	padding-inline: var(--gutter-wrapper-inner-inline, var(--space-m));
 }

--- a/apps/frontend/src/assets/css/variables/spacing.css
+++ b/apps/frontend/src/assets/css/variables/spacing.css
@@ -1,15 +1,5 @@
 :root {
 	--gutter: var(--space-xs);
-	--space-gutter-3xs: var(--space-3xs);
-	--space-gutter-2xs: var(--space-2xs);
-	--space-gutter-xs: var(--space-xs);
-	--space-gutter-s: var(--space-s);
-	--space-gutter-m: var(--space-m);
-	--space-gutter-l: var(--space-l);
-	--space-gutter-xl: var(--space-xl);
-	--space-gutter-2xl: var(--space-2xl);
-	--space-gutter-3xl: var(--space-3xl);
-	--space-gutter-m-3xl: var(--space-m-3xl);
 	--base-radius: var(--space-xs);
 	--radius-s: var(--space-2xs);
 	--radius-m: var(--space-s);

--- a/apps/frontend/src/pages/auth/components/sign-in-form/styles.module.css
+++ b/apps/frontend/src/pages/auth/components/sign-in-form/styles.module.css
@@ -18,9 +18,9 @@
 	z-index: 200;
 	width: 100%;
 	max-width: 590px;
-	padding-block: var(--space-gutter-xl) var(--space-gutter-3xl);
-	padding-inline: var(--space-gutter-m-3xl);
-	margin-inline: var(--space-gutter-s);
+	padding-block: var(--space-xl) var(--space-3xl);
+	padding-inline: var(--space-m-3xl);
+	margin-inline: var(--space-s);
 	font-family: var(--font-family-primary);
 	background-color: var(--color-bg-white);
 	border-radius: var(--radius-l);


### PR DESCRIPTION
Hi guys!

Suggestion is to remove redundant --space-gutter-* variables that are just duplicating --space-* values. My idea was to abstract them, but now I see that it doesn't provide much sense. 

Other Developers might use just --space-* values directly or update spacing.css to add new meaningful and semantic variables - like --nav-padding or --card-gap.

Before:
```css
:root {
	--gutter: var(--space-xs);
	--space-gutter-3xs: var(--space-3xs);
	--space-gutter-2xs: var(--space-2xs);
	--space-gutter-xs: var(--space-xs);
	--space-gutter-s: var(--space-s);
	--space-gutter-m: var(--space-m);
	--space-gutter-l: var(--space-l);
	--space-gutter-xl: var(--space-xl);
	--space-gutter-2xl: var(--space-2xl);
	--space-gutter-3xl: var(--space-3xl);
	--space-gutter-m-3xl: var(--space-m-3xl);
	--base-radius: var(--space-xs);
	--radius-s: var(--space-2xs);
	--radius-m: var(--space-s);
	--radius-l: var(--space-m);
	--radius-xl: var(--space-l);
	--radius-full: 99999px;
	--flow-space: var(--space-xs);
	--stroke: 3px solid var(--color-card-peach);
}
```

After:
```css
:root {
	--gutter: var(--space-xs);
	--base-radius: var(--space-xs);
	--radius-s: var(--space-2xs);
	--radius-m: var(--space-s);
	--radius-l: var(--space-m);
	--radius-xl: var(--space-l);
	--radius-full: 99999px;
	--flow-space: var(--space-xs);
	--stroke: 3px solid var(--color-card-peach);
}
```