### PR TITLE
fix: scrollbar gutter cy-88

### DIFF
--- a/apps/frontend/src/assets/css/reset.css
+++ b/apps/frontend/src/assets/css/reset.css
@@ -18,7 +18,6 @@
 html {
 	text-size-adjust: none;
 	scroll-behavior: smooth;
-	scrollbar-gutter: stable;
 }
 
 html,

--- a/apps/frontend/src/assets/css/reset.css
+++ b/apps/frontend/src/assets/css/reset.css
@@ -17,7 +17,12 @@
 
 html {
 	text-size-adjust: none;
-	scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	html {
+		scroll-behavior: smooth;
+	}
 }
 
 html,

--- a/apps/frontend/src/assets/css/utilities/scrollbar-gutter.css
+++ b/apps/frontend/src/assets/css/utilities/scrollbar-gutter.css
@@ -1,0 +1,3 @@
+.scrollbar-gutter-stable {
+	scrollbar-gutter: stable;
+}

--- a/apps/frontend/src/assets/css/utilities/utilities.css
+++ b/apps/frontend/src/assets/css/utilities/utilities.css
@@ -3,3 +3,4 @@
 @import url("./flow.css");
 @import url("./grid-pattern.css");
 @import url("./responsive.css");
+@import url("./scrollbar-gutter.css");


### PR DESCRIPTION
Hello guys!

[Bug ticket link](https://github.com/orgs/BinaryStudioAcademy/projects/33/views/1?pane=issue&itemId=122210407&issue=BinaryStudioAcademy%7Cbsa-2025-checkly%7C88)

QA team has found a visual bug - with `scrollbar-gutter: stable` ([MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter)), that reserves space for a scrollbar, it also creates an unwanted blank space even when content doesn't overflow. It doesn't look good on sign-in/sing-up pages.

Actions taken:

1. Removed `scrollbar-gutter: stable` from html.
2. Added scrollbar-gutter-stable utility class, that can be used in case this feature to prevent content shifting needs to be applied to a container, or whatever element a Developer is working with.

```css
.scrollbar-gutter-stable {
	scrollbar-gutter: stable;
}
```
