### PR TITLE
fix: update checkIsWhiteRoute function cy-132

### DIFF
--- a/apps/backend/src/plugins/authorization/authorization.plugin.ts
+++ b/apps/backend/src/plugins/authorization/authorization.plugin.ts
@@ -75,9 +75,9 @@ const checkIsWhiteRoute = (url: string, whiteRoutes: string[]): boolean => {
 		return true;
 	}
 
-	const [routeWithoutQuery] = url.split("?") as [string];
+	const [routeWithoutQuery] = url.split("?");
 
-	return whiteRoutes.includes(routeWithoutQuery);
+	return whiteRoutes.includes(routeWithoutQuery as string);
 };
 
 const authorization = fp<AuthPluginOptions>(


### PR DESCRIPTION
Hi guys!

[Bug link](https://github.com/orgs/BinaryStudioAcademy/projects/33?pane=issue&itemId=122660075&issue=BinaryStudioAcademy%7Cbsa-2025-checkly%7C132)

The checkIsWhiteRoute function accepts two params - url (`'/api/v1/auth/login'`) and a list of white routes (like `['/api/v1/auth/login', '/api/v1/auth/register']`) but returns incorrect results. 

Issue is that the function extracted the route part (`'/auth/login'`) via regex and compared it with the full path in the whitelist `['/api/v1/auth/login', '/api/v1/auth/register']`, which would never be true.

Suggestion is to remove redundant regex extraction and just verify if white list includes the full url route (not including query params).

UPD: regex check is restored + replaced route.split("?") with url.split("?").