### PR TITLE
fix: card edges clipping on hover cy-143

### DIFF
--- a/apps/frontend/src/pages/home/components/visual-layouts/styles.module.css
+++ b/apps/frontend/src/pages/home/components/visual-layouts/styles.module.css
@@ -18,7 +18,7 @@
 .layout-list {
 	display: flex;
 	gap: clamp(15px, 2.1vw, 25px);
-	padding-bottom: 7vw;
+	padding: 10px 10px 7vw;
 	overflow: auto hidden;
 	scrollbar-width: none;
 }


### PR DESCRIPTION
### fix: card edges clipping on hover cy-143

### Description:

This PR resolves the clipping issue on the Design Templates cards.

- Adjusted parent container's overflow handling and spacing
- Ensured cards scale smoothly on hover without edges being cut off

Please review and let me know if any additional refinements are required.

### Video Demo:

https://github.com/user-attachments/assets/21a8031f-bea4-4bed-85b6-dc82a6d8d987

