### PR TITLE
fix: block margin overlaps with screen border in small resolution cy-149

### DIFF
--- a/apps/frontend/src/pages/home/components/feedbacks-section/styles.module.css
+++ b/apps/frontend/src/pages/home/components/feedbacks-section/styles.module.css
@@ -57,7 +57,7 @@
 
 @media (width <= 768px) {
 	.grid > * {
-		flex: 0 0 360px;
+		flex: 0 1 360px;
 		height: clamp(180px, 12vw + 100px, 200px);
 	}
 


### PR DESCRIPTION
<img width="402" height="681" alt="image" src="https://github.com/user-attachments/assets/21c45299-1987-44b1-9553-3ec2336c1b05" />
<img width="402" height="952" alt="image" src="https://github.com/user-attachments/assets/7fc59216-722f-4025-a405-3652e51e9ecf" />
