### PR TITLE
fix: update button state in header cy-153

### DIFF
--- a/apps/frontend/src/pages/home/components/header/header.tsx
+++ b/apps/frontend/src/pages/home/components/header/header.tsx
@@ -1,10 +1,13 @@
 import { Link } from "~/libs/components/components.js";
 import { Logo } from "~/libs/components/logo/logo.js";
 import { AppRoute } from "~/libs/enums/app-route.enum.js";
+import { useAppSelector } from "~/libs/hooks/hooks.js";
 
 import styles from "./styles.module.css";
 
 const Header: React.FC = () => {
+	const { user } = useAppSelector(({ auth }) => auth);
+
 	return (
 		<header className={styles["header"]}>
 			<div className="wrapper repel">
@@ -13,9 +16,15 @@ const Header: React.FC = () => {
 					<Link asButtonVariant="secondary" to={AppRoute.ROOT}>
 						Start quiz
 					</Link>
-					<Link asButtonVariant="secondary" to={AppRoute.SIGN_IN}>
-						Sign in
-					</Link>
+					{user ? (
+						<Link asButtonVariant="secondary" to={AppRoute.DASHBOARD}>
+							Profile
+						</Link>
+					) : (
+						<Link asButtonVariant="secondary" to={AppRoute.SIGN_IN}>
+							Sign in
+						</Link>
+					)}
 				</nav>
 			</div>
 		</header>


### PR DESCRIPTION
Update "Sign in" button state in header based on auth status.
Button now displays "Sign In" for not authenticated users and "Profile" for authenticated users.

Note: this will work fully only after merging PR for the protected route, as the authentication check depends on the auth slice, and the logic for fetching and storing the user in that slice is handled in protected route.

<img width="1899" height="718" alt="image" src="https://github.com/user-attachments/assets/0c1edca9-6d62-41c7-9678-b57ff058cbf6" />
