### PR TITLE
fix: change hardcoded image paths with module import pattern cy-161

### DIFF
--- a/apps/frontend/src/pages/home/lib/constants.ts
+++ b/apps/frontend/src/pages/home/lib/constants.ts
@@ -1,18 +1,24 @@
+import {
+	Avatar01,
+	Avatar02,
+	Avatar03,
+} from "~/assets/img/shared/avatars/avatars.img.js";
+
 const FEEDBACKS = [
 	{
-		avatar: "src/assets/img/shared/avatars/avatar-1.svg",
+		avatar: Avatar01,
 		id: 1,
 		name: "Roy",
 		text: "Lorem ipsum dolor amet, consectetur adipiscing elit. Cras sed dui sagittis, scelerisque lectus at, porttitor lectus. Sed libero est, tincidunt eget purus nec, dignissim consequat mauris",
 	},
 	{
-		avatar: "src/assets/img/shared/avatars/avatar-2.svg",
+		avatar: Avatar02,
 		id: 2,
 		name: "Emma",
 		text: "Nulla et nulla pulvinar, congue justo id, cursus ligula. Nunc pharetra sapien libero, vel blandit orci rhoncus ut. Sed aliquam efficitur semper.",
 	},
 	{
-		avatar: "src/assets/img/shared/avatars/avatar-3.svg",
+		avatar: Avatar03,
 		id: 3,
 		name: "Joan",
 		text: "Nullam tempus, elit non tempus molestie, tellus diam sagittis urna, vel viverra velit risus in nunc. Cras in quam leo. Nullam mattis at lacus eget pretium. Etiam quis pulvinar",


### PR DESCRIPTION
### Problem Description:

In the application, all images are imported as modules using statements like:

`export { default as arrowDown } from "./arrow-down.svg";`

This ensures that the images are correctly bundled by the build system and will work both locally and in production.
However, in the testimonial (feedback) section, the avatar images were hardcoded as string paths, for example:

`avatar: "src/assets/img/shared/avatars/avatar-1.svg"`

This works locally because the local development server can serve static assets directly from the filesystem.

### Issue on deployment:

On the deployed version, the hardcoded paths no longer resolve correctly, so the avatars are replaced by placeholders. This happens because:

- The build process copies/optimizes images to a hashed location in the build folder.
- The hardcoded string path "src/assets/img/shared/avatars/avatar-1.svg" does not match the final location of the image in the production bundle.
- Unlike the imported images (import/export), the hardcoded path is not processed by the bundler, so it breaks in production.

### Solution:

Import all images as modules like the rest of the app:

`export { default as Avatar01 } from "./avatar-1.svg";`

Use the imported module in your FEEDBACKS array instead of a hardcoded path:
This ensures the images are included in the build and work correctly in both local and deployed environments.
