### PR TITLE
fix: Prevent Sign In/Sign Up from reloading when receiving an error on submit cy-181

### DIFF
--- a/apps/frontend/src/libs/components/button/button.tsx
+++ b/apps/frontend/src/libs/components/button/button.tsx
@@ -10,7 +10,7 @@ type Properties = {
 	iconOnlySize?: "large" | "medium" | "small";
 	isIconOnly?: boolean;
 	label: string;
-	loader: React.ReactNode;
+	loader?: React.ReactNode;
 	onClick?: React.MouseEventHandler<HTMLButtonElement>;
 	size?: "large" | "small";
 	type?: "button" | "submit";

--- a/apps/frontend/src/libs/components/button/button.tsx
+++ b/apps/frontend/src/libs/components/button/button.tsx
@@ -10,6 +10,7 @@ type Properties = {
 	iconOnlySize?: "large" | "medium" | "small";
 	isIconOnly?: boolean;
 	label: string;
+	loader: React.ReactNode;
 	onClick?: React.MouseEventHandler<HTMLButtonElement>;
 	size?: "large" | "small";
 	type?: "button" | "submit";
@@ -23,6 +24,7 @@ const Button: React.FC<Properties> = ({
 	iconOnlySize = "large",
 	isIconOnly = false,
 	label,
+	loader,
 	onClick,
 	size = "large",
 	type = "button",
@@ -53,6 +55,7 @@ const Button: React.FC<Properties> = ({
 				</span>
 			)}
 			{!isIconOnly && <span>{label}</span>}
+			{loader}
 		</button>
 	);
 };

--- a/apps/frontend/src/libs/components/loader/loader.tsx
+++ b/apps/frontend/src/libs/components/loader/loader.tsx
@@ -9,6 +9,7 @@ type LoaderTheme = "accent" | "brand" | "muted";
 type Properties = {
 	backdrop?: boolean;
 	container?: LoaderContainer;
+	isLoading?: boolean;
 	size?: LoaderSize;
 	theme?: LoaderTheme;
 };
@@ -16,6 +17,7 @@ type Properties = {
 const Loader: React.FC<Properties> = ({
 	container = "fullscreen",
 	backdrop = container === "fullscreen",
+	isLoading = true,
 	size = "large",
 	theme = "brand",
 }: Properties) => {
@@ -30,13 +32,13 @@ const Loader: React.FC<Properties> = ({
 		styles[theme],
 	);
 
-	return (
+	return isLoading ? (
 		<div className={containerClasses}>
 			<div className={spinnerClasses} role="status">
 				<span className="visually-hidden">Loading in progress...</span>
 			</div>
 		</div>
-	);
+	) : null;
 };
 
 export { Loader };

--- a/apps/frontend/src/libs/components/protected-route/protected-route.tsx
+++ b/apps/frontend/src/libs/components/protected-route/protected-route.tsx
@@ -16,10 +16,11 @@ const ProtectedRoute: React.FC = () => {
 	const handle = matches.at(LAST_INDEX)?.handle as RouteHandle;
 	const { access } = handle;
 
-	const { dataStatus, user } = useAppSelector(({ auth }) => auth);
+	const { dataStatus, isPreparing, user } = useAppSelector(({ auth }) => auth);
 
 	const isLoading =
-		dataStatus === DataStatus.PENDING || dataStatus === DataStatus.IDLE;
+		(dataStatus === DataStatus.PENDING || dataStatus === DataStatus.IDLE) &&
+		isPreparing;
 
 	if (isLoading) {
 		return <Loader />;

--- a/apps/frontend/src/modules/auth/slices/auth.slice.ts
+++ b/apps/frontend/src/modules/auth/slices/auth.slice.ts
@@ -8,11 +8,13 @@ import { getCurrentUser, signIn, signUp } from "./actions.js";
 
 type State = {
 	dataStatus: ValueOf<typeof DataStatus>;
+	isPreparing: boolean;
 	user: null | UserDto;
 };
 
 const initialState: State = {
 	dataStatus: DataStatus.IDLE,
+	isPreparing: true,
 	user: null,
 };
 
@@ -20,6 +22,7 @@ const { actions, name, reducer } = createSlice({
 	extraReducers(builder) {
 		builder.addCase(signUp.pending, (state) => {
 			state.dataStatus = DataStatus.PENDING;
+			state.isPreparing = !initialState.isPreparing;
 		});
 		builder.addCase(signUp.fulfilled, (state, action) => {
 			state.dataStatus = DataStatus.FULFILLED;
@@ -29,8 +32,10 @@ const { actions, name, reducer } = createSlice({
 			state.dataStatus = DataStatus.REJECTED;
 			state.user = null;
 		});
+
 		builder.addCase(getCurrentUser.pending, (state) => {
 			state.dataStatus = DataStatus.PENDING;
+			state.isPreparing = initialState.isPreparing;
 		});
 		builder.addCase(getCurrentUser.fulfilled, (state, action) => {
 			state.dataStatus = DataStatus.FULFILLED;
@@ -43,6 +48,7 @@ const { actions, name, reducer } = createSlice({
 
 		builder.addCase(signIn.pending, (state) => {
 			state.dataStatus = DataStatus.PENDING;
+			state.isPreparing = !initialState.isPreparing;
 		});
 		builder.addCase(signIn.fulfilled, (state, action) => {
 			state.dataStatus = DataStatus.FULFILLED;

--- a/apps/frontend/src/pages/auth/auth.tsx
+++ b/apps/frontend/src/pages/auth/auth.tsx
@@ -1,9 +1,10 @@
 import React, { type JSX, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { AppRoute } from "~/libs/enums/enums.js";
+import { AppRoute, DataStatus } from "~/libs/enums/enums.js";
 import {
 	useAppDispatch,
+	useAppSelector,
 	useCallback,
 	useLocation,
 } from "~/libs/hooks/hooks.js";
@@ -20,6 +21,11 @@ const Auth: React.FC = () => {
 	const dispatch = useAppDispatch();
 	const { pathname } = useLocation();
 	const navigate = useNavigate();
+
+	const { dataStatus } = useAppSelector(({ auth }) => auth);
+
+	const isLoading =
+		dataStatus === DataStatus.PENDING || dataStatus === DataStatus.IDLE;
 
 	useEffect(() => {
 		navigation.setNavigate(navigate);
@@ -42,11 +48,15 @@ const Auth: React.FC = () => {
 	const getScreen = (screen: string): JSX.Element => {
 		switch (screen) {
 			case AppRoute.SIGN_IN: {
-				return <SignInForm onSubmit={handleSignInSubmit} />;
+				return (
+					<SignInForm isLoading={isLoading} onSubmit={handleSignInSubmit} />
+				);
 			}
 
 			case AppRoute.SIGN_UP: {
-				return <SignUpForm onSubmit={handleSignUpSubmit} />;
+				return (
+					<SignUpForm isLoading={isLoading} onSubmit={handleSignUpSubmit} />
+				);
 			}
 		}
 

--- a/apps/frontend/src/pages/auth/components/sign-in-form/sign-in-form.tsx
+++ b/apps/frontend/src/pages/auth/components/sign-in-form/sign-in-form.tsx
@@ -13,6 +13,7 @@ import {
 	Button,
 	DecorativeImage,
 	Input,
+	Loader,
 } from "~/libs/components/components.js";
 import { Logo } from "~/libs/components/logo/logo.js";
 import { AppRoute } from "~/libs/enums/enums.js";
@@ -29,10 +30,14 @@ import { DEFAULT_SIGN_IN_PAYLOAD } from "../sign-in-form/libs/constants.js";
 import styles from "./styles.module.css";
 
 type Properties = {
+	isLoading: boolean;
 	onSubmit: (payload: UserSignInRequestDto) => void;
 };
 
-const SignInForm: React.FC<Properties> = ({ onSubmit }: Properties) => {
+const SignInForm: React.FC<Properties> = ({
+	isLoading,
+	onSubmit,
+}: Properties) => {
 	const pinkStarsClasses = getClassNames(
 		styles["floating-image"],
 		styles["pink-stars"],
@@ -119,7 +124,18 @@ const SignInForm: React.FC<Properties> = ({ onSubmit }: Properties) => {
 							type="password"
 						/>
 					</div>
-					<Button label="Sign In" type="submit" />
+					<Button
+						label="Sign In"
+						loader={
+							<Loader
+								container="inline"
+								isLoading={isLoading}
+								size="small"
+								theme="accent"
+							/>
+						}
+						type="submit"
+					/>
 				</form>
 				<DecorativeImage className={pinkStarsClasses} src={StarsPink01} />
 				<DecorativeImage className={cupClasses} src={CupGreen} />

--- a/apps/frontend/src/pages/auth/components/sign-up-form/sign-up-form.tsx
+++ b/apps/frontend/src/pages/auth/components/sign-up-form/sign-up-form.tsx
@@ -12,6 +12,7 @@ import {
 	Button,
 	DecorativeImage,
 	Input,
+	Loader,
 } from "~/libs/components/components.js";
 import { Logo } from "~/libs/components/logo/logo.js";
 import { AppRoute } from "~/libs/enums/app-route.enum.js";
@@ -29,10 +30,14 @@ import { DEFAULT_SIGN_UP_PAYLOAD } from "./libs/constants.js";
 import styles from "./sign-up-form.module.css";
 
 type Properties = {
+	isLoading: boolean;
 	onSubmit: (payload: UserSignUpRequestDto) => void;
 };
 
-const SignUpForm: React.FC<Properties> = ({ onSubmit }: Properties) => {
+const SignUpForm: React.FC<Properties> = ({
+	isLoading,
+	onSubmit,
+}: Properties) => {
 	const { control, errors, handleSubmit } =
 		useAppForm<SignUpFormValidationSchema>({
 			defaultValues: { ...DEFAULT_SIGN_UP_PAYLOAD, confirmPassword: "" },
@@ -131,7 +136,18 @@ const SignUpForm: React.FC<Properties> = ({ onSubmit }: Properties) => {
 							type="password"
 						/>
 					</div>
-					<Button label="Create an account" type="submit" />
+					<Button
+						label="Create an account"
+						loader={
+							<Loader
+								container="inline"
+								isLoading={isLoading}
+								size="small"
+								theme="accent"
+							/>
+						}
+						type="submit"
+					/>
 				</form>
 				<DecorativeImage className={orangeClasses} src={OrangeWhole} />
 				<DecorativeImage className={carClasses} src={Car} />


### PR DESCRIPTION
Thanks to Olena's comment, the next issues were resolved:

1. Loader is shown for every pending action in auth
2. Loader is not shown on register/login request

What was done:
- The _Loader_ was modified to easily call it from different places
- The _Button_ was modified to allow it to contain a _Loader_
- A flag was added to _Auth slices_ to show _Loader_ only when the page is getting ready
- _Auth_ checks the state status and passes it to the forms 
