### PR TITLE
fix: Add profile link in burger/user menu cy-174

### DIFF
--- a/apps/frontend/src/libs/components/app-header/app-header.tsx
+++ b/apps/frontend/src/libs/components/app-header/app-header.tsx
@@ -6,6 +6,7 @@ import {
 	profileDefault,
 } from "~/assets/img/header/header.img.js";
 import { Link } from "~/libs/components/components.js";
+import { AppRoute } from "~/libs/enums/app-route.enum.js";
 import { getClassNames } from "~/libs/helpers/helpers.js";
 import { useAppSelector, useDropdownMenu } from "~/libs/hooks/hooks.js";
 
@@ -62,11 +63,13 @@ const AppHeader: React.FC = () => {
 			</div>
 
 			<div className={styles["user-section"]} ref={menuReference}>
-				<img
-					alt="User profile"
-					className={styles["user-image"]}
-					src={profileDefault}
-				/>
+				<Link to={AppRoute.PROFILE}>
+					<img
+						alt="User profile"
+						className={styles["user-image"]}
+						src={profileDefault}
+					/>
+				</Link>
 				<div className={styles["user-name-arrow"]}>
 					<span className={styles["user-name"]}>{displayName}</span>
 					<button

--- a/apps/frontend/src/libs/components/app-header/styles.module.css
+++ b/apps/frontend/src/libs/components/app-header/styles.module.css
@@ -215,6 +215,10 @@
 	transform: rotate(-45deg);
 }
 
+.menu-user-profile {
+	display: none;
+}
+
 @media (width < 1024px) {
 	.user-image,
 	.user-name-arrow {
@@ -225,5 +229,9 @@
 		display: flex;
 		flex-direction: column;
 		justify-content: space-around;
+	}
+
+	.menu-user-profile {
+		display: block;
 	}
 }

--- a/apps/frontend/src/libs/components/app-header/user-menu.tsx
+++ b/apps/frontend/src/libs/components/app-header/user-menu.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FiLogOut } from "react-icons/fi";
+import { FiLogOut, FiUser } from "react-icons/fi";
 import { MdDashboard } from "react-icons/md";
 
 import { Plan } from "~/assets/img/side-panel/side-panel.img.js";
@@ -22,6 +22,13 @@ const UserMenu: React.FC<Properties> = ({ isOpen }) => {
 	return (
 		<nav aria-label="User menu" className={menuDropdownClass}>
 			<ul>
+				<NavigationItem
+					buttonText="Profile"
+					buttonType="user-menu"
+					className={styles["menu-user-profile"]}
+					icon={<FiUser />}
+					navigateTo={AppRoute.PROFILE}
+				/>
 				<NavigationItem
 					buttonText="Dashboard"
 					buttonType="user-menu"

--- a/apps/frontend/src/libs/components/navigation-item/navigation-item.tsx
+++ b/apps/frontend/src/libs/components/navigation-item/navigation-item.tsx
@@ -13,7 +13,7 @@ type ButtonType = "logout" | "side-panel" | "user-menu";
 type Properties = {
 	buttonText: string;
 	buttonType: ButtonType;
-	className?: string;
+	className?: string | undefined;
 	icon: ReactNode;
 	navigateTo: ValueOf<typeof AppRoute>;
 };

--- a/apps/frontend/src/libs/enums/app-route.enum.ts
+++ b/apps/frontend/src/libs/enums/app-route.enum.ts
@@ -2,6 +2,7 @@ const AppRoute = {
 	DASHBOARD: "/dashboard",
 	NOT_FOUND: "*",
 	PLAN: "/plan",
+	PROFILE: "/dashboard/profile",
 	ROOT: "/",
 	SIGN_IN: "/sign-in",
 	SIGN_UP: "/sign-up",


### PR DESCRIPTION
Added profile link at burger menu. Added link on profile image click both headed to dashboard/profile

dashboard/profile - currently is not careated it is a someone`s separated task

![chrome_gdbQd50XcT](https://github.com/user-attachments/assets/671184df-b190-4595-8fa7-6022fd8c2159)


