### PR TITLE
fix: remove list-style-type disc cy-206

### DIFF
--- a/apps/frontend/src/pages/home/components/visual-layouts/styles.module.css
+++ b/apps/frontend/src/pages/home/components/visual-layouts/styles.module.css
@@ -18,6 +18,7 @@
 	gap: clamp(15px, 2.1vw, 25px);
 	padding: 10px;
 	overflow: auto hidden;
+	list-style-type: none;
 	scrollbar-width: none;
 }
 


### PR DESCRIPTION
### Bug
In the "Sample visual layouts" section, list bullet points (•) appear between each card when they should be hidden.

Fix: removed default list styling by setting `list-style-type: none` on the list container.