### PR TITLE
fix: visual layouts cy-208

### DIFF
--- a/apps/frontend/src/pages/home/components/footer/styles.module.css
+++ b/apps/frontend/src/pages/home/components/footer/styles.module.css
@@ -7,7 +7,7 @@
 
 .container {
 	--cluster-direction: column;
-	--cluster-vertical-alignment: flex-start;
+	--cluster-vertical-alignment: center;
 	--gutter: var(--space-m);
 
 	padding-block: var(--space-m);
@@ -15,7 +15,7 @@
 
 .nav-links {
 	--cluster-direction: column;
-	--cluster-vertical-alignment: flex-start;
+	--cluster-vertical-alignment: center;
 	--gutter: var(--space-xs);
 }
 

--- a/apps/frontend/src/pages/home/components/visual-layouts/visual-layouts.tsx
+++ b/apps/frontend/src/pages/home/components/visual-layouts/visual-layouts.tsx
@@ -35,6 +35,7 @@ const VisualLayouts: React.FC = () => {
 					<ul
 						aria-label="Available layout options"
 						className={styles["layout-list"]}
+						data-list
 					>
 						{layoutExamples.map((example) => (
 							<li


### PR DESCRIPTION
Hello!

Bug #208 

1. Fixed visual layouts to remove the bullet points from the `ul`.
2. Minor update in landing footer to center the elements on the small screen.