### PR TITLE
fix(frontend): remove sign-up form built-in validation

### DIFF
--- a/apps/frontend/src/pages/auth/components/sign-up-form/sign-up-form.tsx
+++ b/apps/frontend/src/pages/auth/components/sign-up-form/sign-up-form.tsx
@@ -96,6 +96,7 @@ const SignUpForm: React.FC<Properties> = ({
 				<form
 					aria-labelledby="sign-up-title"
 					className={getClassNames(sharedStyles["form"], "cluster")}
+					noValidate
 					onSubmit={handleFormSubmit}
 				>
 					<div className="flow-loose">


### PR DESCRIPTION
![sign-up](https://github.com/user-attachments/assets/f72d4da6-ea12-41e6-b703-ef2d8b50f149)

Now we have only one custom validation for sign-up form