### PR TITLE
217 feat merge test automation repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build
 # misc
 .DS_Store
 .env
+
+# Testing
+/playwright-report/

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -18,3 +18,6 @@ ignore:
   - apps/frontend/node_modules
   - apps/backend/build
   - apps/backend/node_modules
+  - packages/testing/.gitignore
+  - packages/testing/node_modules
+  - packages/testing/playwright-report

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,6 @@
 CHANGELOG.md
 docs/requirements/*.md
+playwright-report/
+test-results/
+packages/testing/playwright-report/
+packages/testing/test-results/

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
 		"testing:ui:prod": "npm -w @checkly/testing run test:ui:prod",
 		"testing:api:prod": "npm -w @checkly/testing run test:api:prod",
 		"testing:all:prod": "npm -w @checkly/testing run test:all:prod",
-		"testing:report": "npm -w @checkly/testing run report"
+		"testing:report": "npm -w @checkly/testing run report",
+		"postinstall": "npm -w @checkly/testing run pw:install"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "19.8.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,15 @@
 		"lint:trash": "knip",
 		"format": "npm run _prettier -- --write",
 		"lint": "concurrently \"npm:lint:*\" && npm run lint --workspaces",
-		"ci:prepare": "simple-git-hooks"
+		"ci:prepare": "simple-git-hooks",
+		"testing:test": "npm -w @checkly/testing run test",
+		"testing:ui": "npm -w @checkly/testing run test:ui",
+		"testing:api": "npm -w @checkly/testing run test:api",
+		"testing:all:local": "npm -w @checkly/testing run test:all:local",
+		"testing:ui:prod": "npm -w @checkly/testing run test:ui:prod",
+		"testing:api:prod": "npm -w @checkly/testing run test:api:prod",
+		"testing:all:prod": "npm -w @checkly/testing run test:all:prod",
+		"testing:report": "npm -w @checkly/testing run report"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "19.8.1",

--- a/packages/testing/.env.example
+++ b/packages/testing/.env.example
@@ -1,0 +1,8 @@
+# Create multiple .env files (.env.local, .env.production) in the root directory, with the following content:
+# URL - Production
+FRONTEND_URL=http://checkly.eu-north-1.elasticbeanstalk.com/
+API_URL=http://checkly.eu-north-1.elasticbeanstalk.com/api/v1
+
+# URL - Local
+FRONTEND_URL=http://localhost:3000/
+API_URL=http://localhost:3001/api/v1/

--- a/packages/testing/.gitignore
+++ b/packages/testing/.gitignore
@@ -1,0 +1,12 @@
+# Environment Variables
+.env
+.env.local
+.env.production
+
+# Playwright
+/node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,130 @@
+# BSA 2025 – Checkly Automation Test
+
+Automated API and UI tests for the Checkly project, developed as part of the Binary Studio Academy 2025 program.
+
+This project uses [Playwright](https://playwright.dev/) to test both backend and frontend functionality of Checkly.
+Includes Continuous Integration via GitHub Actions and generates HTML test reports as build artifacts.
+
+---
+
+## 📦 Tech Stack
+
+- [Playwright](https://playwright.dev/)
+- [TypeScript](https://www.typescriptlang.org/)
+- [Faker](https://www.npmjs.com/package/@faker-js/faker) – fake test data
+- [Ajv](https://ajv.js.org/) – schema validation
+- [dotenv](https://www.npmjs.com/package/dotenv) – environment configuration
+- GitHub Actions – CI/CD pipeline
+
+---
+
+## 🚀 Getting Started
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/VictorVagabculov/BSA-2025-Checkly-Automation-Test.git
+cd BSA-2025-Checkly-Automation-Test
+```
+
+### 2. Install dependencies
+
+```bash
+npm install
+```
+
+### 3. Install Playwright browsers
+
+```bash
+npx playwright install
+```
+
+### 4. Create a `.env` file (or `.env.local`)
+
+```env
+API_URL=http://localhost:3001/api/v1/
+FRONTEND_URL=http://localhost:3000/
+```
+
+> ⚠️ **Important**: Make sure your URLs end with a `/`.
+
+---
+
+## 🧪 Running the Tests
+
+### Run all tests
+
+```bash
+npm test
+```
+
+### Run only API tests
+
+```bash
+npx playwright test --project=api
+```
+
+### Run only UI tests
+
+```bash
+npx playwright test --project=ui
+```
+
+### Run a specific test file
+
+```bash
+npx playwright test tests/api/auth/sign-in.api.spec.ts --project=api
+npx playwright test tests/ui/auth/sign-in.ui.spec.ts --project=ui
+```
+
+### View the HTML report
+
+```bash
+npm run report
+# Then open: playwright-report/index.html
+```
+
+---
+
+## 🧠 Folder Structure
+
+```
+.
+├── api/
+│   ├── controllers/          # API controllers
+│   ├── helpers/              # Data generators, schema validator, etc.
+│   └── schemas/              # OpenAPI schemas
+│
+├── tests/
+│   ├── api/                  # API tests
+│   │   └── authentication/
+│   │   └── helpers/
+│   └── ui/                   # UI tests
+│       └── auth/
+│
+├── ui/
+│   ├── controllers/          # UI Page Objects
+│   └── utils/                # UI helpers (coming soon)
+│
+├── .env                      # Environment variables
+├── playwright.config.ts      # Playwright test config
+├── tsconfig.json
+└── package.json
+```
+
+---
+
+## ✨ Features
+
+- ✅ Fully separated UI and API test projects
+- ✅ Type-safe test data using Faker
+- ✅ Schema validation with Ajv
+- ✅ Page Object Model for UI interactions
+- ✅ Custom helper methods for repeated logic
+- ✅ Multi-environment setup via `.env` files
+
+---
+
+## ✅ TODO
+
+- [x] Finalize CI configuration with production deployment

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,8 +1,8 @@
-# BSA 2025 – Checkly Automation Test
+# BSA 2025 – Checkly Automation Testing
 
-Automated API and UI tests for the Checkly project, developed as part of the Binary Studio Academy 2025 program.
+Automated API and UI tests for the Checkly monorepo, developed as part of the Binary Studio Academy 2025 program.
 
-This project uses [Playwright](https://playwright.dev/) to test both backend and frontend functionality of Checkly.
+This package uses [Playwright](https://playwright.dev/) to test both backend and frontend functionality of Checkly.
 Includes Continuous Integration via GitHub Actions and generates HTML test reports as build artifacts.
 
 ---
@@ -20,111 +20,87 @@ Includes Continuous Integration via GitHub Actions and generates HTML test repor
 
 ## 🚀 Getting Started
 
-### 1. Clone the repository
-
-```bash
-git clone https://github.com/VictorVagabculov/BSA-2025-Checkly-Automation-Test.git
-cd BSA-2025-Checkly-Automation-Test
-```
-
-### 2. Install dependencies
+### 1. Install dependencies (from the monorepo root)
 
 ```bash
 npm install
 ```
 
-### 3. Install Playwright browsers
+> 🛠 This will also automatically install Playwright browsers for testing.
 
-```bash
-npx playwright install
-```
+### 2. Environment variables
 
-### 4. Create a `.env` file (or `.env.local`)
+Create `.env.local` and `.env.production` inside `packages/testing/`:
 
 ```env
-API_URL=http://localhost:3001/api/v1/
+# Local environment
 FRONTEND_URL=http://localhost:3000/
+API_URL=http://localhost:3001/api/v1/
+
+# Production environment
+FRONTEND_URL=http://checkly.eu-north-1.elasticbeanstalk.com/
+API_URL=http://checkly.eu-north-1.elasticbeanstalk.com/api/v1/
 ```
 
-> ⚠️ **Important**: Make sure your URLs end with a `/`.
+> ⚠ **Important:** Make sure URLs end with a `/`.
 
 ---
 
 ## 🧪 Running the Tests
 
-### Run all tests
+From the **monorepo root**:
 
 ```bash
-npm test
-```
-
-### Run only API tests
-
-```bash
-npx playwright test --project=api
-```
-
-### Run only UI tests
-
-```bash
-npx playwright test --project=ui
-```
-
-### Run a specific test file
-
-```bash
-npx playwright test tests/api/auth/sign-in.api.spec.ts --project=api
-npx playwright test tests/ui/auth/sign-in.ui.spec.ts --project=ui
-```
-
-### View the HTML report
-
-```bash
-npm run report
-# Then open: playwright-report/index.html
+npm run testing:test       # Run all tests (local env)
+npm run testing:ui         # Run only UI tests
+npm run testing:api        # Run only API tests
+npm run testing:report     # View the last HTML report
 ```
 
 ---
 
-## 🧠 Folder Structure
+## 📂 Folder Structure
 
 ```
-.
-├── api/
-│   ├── controllers/          # API controllers
-│   ├── helpers/              # Data generators, schema validator, etc.
-│   └── schemas/              # OpenAPI schemas
-│
-├── tests/
-│   ├── api/                  # API tests
-│   │   └── authentication/
-│   │   └── helpers/
-│   └── ui/                   # UI tests
-│       └── auth/
-│
-├── ui/
-│   ├── controllers/          # UI Page Objects
-│   └── utils/                # UI helpers (coming soon)
-│
-├── .env                      # Environment variables
-├── playwright.config.ts      # Playwright test config
+packages/testing
+├── .env.example
+├── .env.local
+├── .env.production
+├── .gitignore
+├── package.json
+├── playwright.config.ts
+├── README.md
 ├── tsconfig.json
-└── package.json
+├── playwright-report/ # HTML report
+└── tests/
+├── api/
+│ ├── auth/
+│ ├── controllers/
+│ ├── fixtures/
+│ ├── helpers/
+│ └── schemas/
+├── ui/
+│ ├── auth/
+│ ├── controllers/
+│ ├── fixtures/
+│ ├── helpers/
+│ └── landing/
+└── utils/
 ```
 
 ---
 
 ## ✨ Features
 
-- ✅ Fully separated UI and API test projects
-- ✅ Type-safe test data using Faker
-- ✅ Schema validation with Ajv
-- ✅ Page Object Model for UI interactions
-- ✅ Custom helper methods for repeated logic
-- ✅ Multi-environment setup via `.env` files
+- ✅ Separate UI and API projects
+- ✅ Page Object Model for UI
+- ✅ Faker for type-safe test data
+- ✅ Ajv for schema validation
+- ✅ Multi-environment support via `.env` files
+- ✅ CI-ready with GitHub Actions
 
 ---
 
-## ✅ TODO
+## 📌 TODO
 
-- [x] Finalize CI configuration with production deployment
+- [ ] Integrate CI workflow (`playwright.yml`)

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -16,7 +16,8 @@
 		"test:ui:prod": "dotenv -e .env.production -- npx playwright test --project=ui",
 		"test:api:prod": "dotenv -e .env.production -- npx playwright test --project=api",
 		"test:all:prod": "dotenv -e .env.production -- npx playwright test",
-		"report": "npx playwright show-report"
+		"report": "npx playwright show-report",
+		"pw:install": "playwright install"
 	},
 	"dependencies": {
 		"@faker-js/faker": "^9.9.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@checkly/testing",
+	"private": true,
+	"version": "1.0.0",
+	"description": "Automated API and UI tests for the Checkly project (Binary Studio Academy 2025)",
+	"type": "commonjs",
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"scripts": {
+		"postinstall": "npx playwright install --with-deps",
+		"test": "npx playwright test",
+		"test:ui": "dotenv -e .env.local -- npx playwright test --project=ui",
+		"test:api": "dotenv -e .env.local -- npx playwright test --project=api",
+		"test:all:local": "dotenv -e .env.local -- npx playwright test",
+		"test:ui:prod": "dotenv -e .env.production -- npx playwright test --project=ui",
+		"test:api:prod": "dotenv -e .env.production -- npx playwright test --project=api",
+		"test:all:prod": "dotenv -e .env.production -- npx playwright test",
+		"report": "npx playwright show-report"
+	},
+	"dependencies": {
+		"@faker-js/faker": "^9.9.0",
+		"ajv": "^8.17.1"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.54.1",
+		"@types/node": "^24.1.0",
+		"dotenv": "^17.2.1",
+		"dotenv-cli": "^10.0.0",
+		"typescript": "^5.5.4"
+	}
+}

--- a/packages/testing/playwright.config.ts
+++ b/packages/testing/playwright.config.ts
@@ -1,0 +1,69 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
+import fs from "node:fs";
+import dotenv from "dotenv";
+// --- Load .env from the package folder (works even if you don't use dotenv-cli)
+const pkgDir = __dirname; // packages/testing
+const nodeEnv = process.env["NODE_ENV"];
+const envHint = nodeEnv === "production" ? ".env.production" : ".env.local";
+const candidateEnvs = [
+	path.resolve(pkgDir, envHint),
+	path.resolve(pkgDir, ".env"), // fallback
+];
+
+for (const p of candidateEnvs) {
+	if (fs.existsSync(p)) {
+		dotenv.config({ path: p });
+		break;
+	}
+}
+
+// --- Helper to read env vars without TS warnings
+const env = (k: string, fallback?: string) => process.env[k] ?? fallback;
+
+// --- Required environment variables (with sane defaults for local dev)
+const FRONTEND_URL = env("FRONTEND_URL", "http://localhost:3000/");
+const API_URL = env("API_URL", "http://localhost:3001/api/v1/");
+// Build the base config
+const cfg: Parameters<typeof defineConfig>[0] = {
+	testDir: ".",
+	outputDir: "/test-results",
+	reporter: [["list"], ["html", { open: "never" }]],
+
+	timeout: 30_000,
+	expect: { timeout: 5_000 },
+	fullyParallel: true,
+	forbidOnly: !!process.env["CI"],
+	retries: process.env["CI"] ? 1 : 0,
+	use: {
+		baseURL: FRONTEND_URL,
+		trace: "on-first-retry",
+		screenshot: "only-on-failure",
+		video: "retain-on-failure",
+		actionTimeout: 10_000,
+	},
+	projects: [
+		{
+			name: "ui",
+			testDir: path.resolve(pkgDir, "tests/ui"),
+			use: {
+				baseURL: FRONTEND_URL,
+				...devices["Desktop Chrome"],
+			},
+		},
+		{
+			name: "api",
+			testDir: path.resolve(pkgDir, "tests/api"),
+			use: {
+				baseURL: API_URL,
+			},
+		},
+	],
+};
+
+// Add workers only in CI
+if (process.env["CI"]) {
+	(cfg as any).workers = 2;
+}
+
+export default defineConfig(cfg);

--- a/packages/testing/tests/api/auth/auth-me.api.spec.ts
+++ b/packages/testing/tests/api/auth/auth-me.api.spec.ts
@@ -1,0 +1,54 @@
+import { test } from "@tests/api/fixtures/base-fixtures";
+
+import {
+	expectSuccessfulAuthMe,
+	expectAuthMeError,
+	expectSuccessfulRegistration,
+} from "@tests/api/helpers/auth-test-helpers";
+import { generateUser } from "@test-helpers-api/generators";
+
+const user = {
+	id: 0,
+	token: "",
+};
+
+test.beforeAll(async ({ api }) => {
+	const newUser = generateUser();
+	const { responseBody } = await expectSuccessfulRegistration(
+		api,
+		newUser.email,
+		newUser.name,
+		newUser.password,
+	);
+	user.id = responseBody.user.id;
+	user.token = responseBody.token;
+});
+
+test("[CHECKLY-58] Fetch authenticated user with a valid JWT token", async ({
+	api,
+}) => {
+	await expectSuccessfulAuthMe(api, user.token, user.id);
+});
+
+test.describe("[CHECKLY-57] Fetch authenticated user with an invalid JWT token", async () => {
+	const invalidTokenTests = [
+		{ name: "Invalid Token Format", value: "invalid-token-format" },
+		{
+			name: "Valid Format but Altered",
+			value:
+				"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjEsImlhdCI6MTc1Mzg4NzY1Dg3NjU1fQ.0xjdSQDySZYHxn9q-TZknKdC1_DJzQirzZPh8RHbWREvalid-but-altered",
+		},
+	];
+
+	for (const testCase of invalidTokenTests) {
+		test(testCase.name, async ({ api }) => {
+			await expectAuthMeError(api, testCase.value);
+		});
+	}
+});
+
+test("[CHECKLY-56] Fetch authenticated user without a JWT token", async ({
+	api,
+}) => {
+	await expectAuthMeError(api, "");
+});

--- a/packages/testing/tests/api/auth/sign-in.api.spec.ts
+++ b/packages/testing/tests/api/auth/sign-in.api.spec.ts
@@ -1,0 +1,98 @@
+import { test } from "@tests/api/fixtures/base-fixtures";
+import {
+	expectSuccessfulRegistration,
+	expectSuccessfulLogin,
+	expectLoginError,
+} from "@tests/api/helpers/auth-test-helpers";
+import { faker } from "@faker-js/faker";
+import { generateUser } from "@test-helpers-api/generators";
+
+const user = {
+	name: "",
+	email: "",
+	password: "",
+};
+
+test.beforeAll(async ({ api }) => {
+	const newUser = generateUser();
+	user.name = newUser.name;
+	user.email = newUser.email;
+	user.password = newUser.password;
+	await expectSuccessfulRegistration(api, user.email, user.name, user.password);
+});
+
+test("[CHECKLY-37] Sign In API | Successful Login Attempt", async ({ api }) => {
+	await expectSuccessfulLogin(api, user.email, user.password);
+});
+
+test("[CHECKLY-30] Sign In API | Unsuccessful Login Attempt - Wrong Password", async ({
+	api,
+}) => {
+	await expectLoginError(
+		api,
+		user.email,
+		"IncorrectPassword123",
+		401,
+		"Wrong password",
+	);
+});
+
+test("[CHECKLY-29] Sign In API | Unsuccessful Login Attempt - Unregistered Email", async ({
+	api,
+}) => {
+	await expectLoginError(
+		api,
+		faker.internet.email(),
+		"ValidPassword123",
+		404,
+		"User not found",
+	);
+});
+
+test("[CHECKLY-35] Sign In API | Empty Password Field", async ({ api }) => {
+	await expectLoginError(api, user.email, "", 422, "Field is required");
+});
+
+test("[CHECKLY-34] Sign In API | Empty Email Field", async ({ api }) => {
+	await expectLoginError(api, "", "ValidPassword123", 422, "Field is required");
+});
+
+test.describe("[CHECKLY-36] Sign In API | Malformatted Email", async () => {
+	const malformattedEmailTests = [
+		{ name: "Email without @", value: "test.com" },
+		{ name: "Missing local part", value: "@domain.com" },
+		{ name: "Missing domain part", value: "test@" },
+		{ name: "Missing top-level domain", value: "test@domain" },
+		{ name: "Dot as first character of local part", value: ".test@domain.com" },
+		{ name: "Dot as last character of local part", value: "test.@domain.com" },
+		{ name: "Consecutive dots in local part", value: "test..test@domain.com" },
+		{
+			name: "Dot as first character of domain part",
+			value: "test@.domain.com",
+		},
+		{ name: "Dot as last character of domain part", value: "test@domain." },
+		{ name: "Consecutive dots in domain part", value: "test@domain..com" },
+		{ name: "Space in local part", value: "test test@domain.com" },
+		{ name: "Space in domain part", value: "test@domain com" },
+		{
+			name: "Hyphen as first character of domain part",
+			value: "test@-domain.com",
+		},
+		{ name: "Hyphen as last character of domain part", value: "test@domain-" },
+		{ name: "Invalid characters in domain part", value: "test@doma_in.com" },
+		{ name: "Non-Latin characters #1", value: "тест@домен.com" },
+		{ name: "Non-Latin characters in domain part", value: "屁股@混蛋.中国" },
+	];
+
+	for (const testCase of malformattedEmailTests) {
+		test(testCase.name, async ({ api }) => {
+			await expectLoginError(
+				api,
+				testCase.value,
+				"ValidPassword123",
+				422,
+				"Invalid email format",
+			);
+		});
+	}
+});

--- a/packages/testing/tests/api/auth/sign-up.api.spec.ts
+++ b/packages/testing/tests/api/auth/sign-up.api.spec.ts
@@ -1,0 +1,279 @@
+import { test } from "@tests/api/fixtures/sign-up-fixtures";
+import {
+	expectSuccessfulRegistration,
+	expectRegistrationError,
+} from "@tests/api/helpers/auth-test-helpers";
+import { faker } from "@faker-js/faker";
+
+test.describe("[CHECKLY-1] Successful registration with valid data", () => {
+	test("Regular valid data", async ({ api, validUser }) => {
+		await expectSuccessfulRegistration(
+			api,
+			validUser.email,
+			validUser.name,
+			validUser.password,
+		);
+	});
+
+	test("Name with maximum length", async ({ api, validUser }) => {
+		const longName = "a".repeat(32);
+		await expectSuccessfulRegistration(
+			api,
+			validUser.email,
+			longName,
+			validUser.password,
+		);
+	});
+
+	test("Name with minimum length", async ({ api, validUser }) => {
+		await expectSuccessfulRegistration(
+			api,
+			validUser.email,
+			"Max",
+			validUser.password,
+		);
+	});
+
+	test("Name Contains Hyphen", async ({ api, validUser }) => {
+		await expectSuccessfulRegistration(
+			api,
+			validUser.email,
+			"Max-Mustermann",
+			validUser.password,
+		);
+	});
+
+	test("Email with Minimum Length", async ({ api, validUser }) => {
+		const minEmail = `${faker.string.alpha(1)}@${faker.string.alpha(1)}.${faker.string.alpha(1)}`;
+		await expectSuccessfulRegistration(
+			api,
+			minEmail,
+			validUser.name,
+			validUser.password,
+		);
+	});
+
+	test("Email with Maximum Length", async ({ api, validUser }) => {
+		const maxEmail = `${faker.string.alpha(1).repeat(35)}@${faker.string.alpha(1)}.${faker.string.alpha(1).repeat(32)}`;
+		await expectSuccessfulRegistration(
+			api,
+			maxEmail,
+			validUser.name,
+			validUser.password,
+		);
+	});
+
+	test("Password with Minimum Length", async ({ api, validUser }) => {
+		await expectSuccessfulRegistration(
+			api,
+			validUser.email,
+			validUser.name,
+			"123456Aa",
+		);
+	});
+
+	test("Password with Maximum Length", async ({ api, validUser }) => {
+		const maxPassword = "Aa" + "7".repeat(30);
+		await expectSuccessfulRegistration(
+			api,
+			validUser.email,
+			validUser.name,
+			maxPassword,
+		);
+	});
+});
+
+test("[CHECKLY-2] Attempt to register with an already registered email", async ({
+	api,
+	validUser,
+}) => {
+	await expectSuccessfulRegistration(
+		api,
+		validUser.email,
+		validUser.name,
+		validUser.password,
+	);
+
+	await expectRegistrationError(
+		api,
+		validUser.email,
+		validUser.name,
+		validUser.password,
+		400,
+		"Email already in use",
+	);
+});
+
+test.describe("[CHECKLY-3] Registration fails with invalid email format", () => {
+	const invalidEmailTests = [
+		{ name: "Email without @", value: "test.com" },
+		{ name: "Missing local part", value: "@domain.com" },
+		{ name: "Missing domain part", value: "test@" },
+		{ name: "Missing top-level domain", value: "test@domain" },
+		{ name: "Dot as first character of local part", value: ".test@domain.com" },
+		{ name: "Dot as last character of local part", value: "test.@domain.com" },
+		{ name: "Consecutive dots in local part", value: "test..test@domain.com" },
+		{
+			name: "Dot as first character of domain part",
+			value: "test@.domain.com",
+		},
+		{ name: "Dot as last character of domain part", value: "test@domain." },
+		{ name: "Consecutive dots in domain part", value: "test@domain..com" },
+		{ name: "Space in local part", value: "test test@domain.com" },
+		{ name: "Space in domain part", value: "test@domain com" },
+		{
+			name: "Hyphen as first character of domain part",
+			value: "test@-domain.com",
+		},
+		{ name: "Hyphen as last character of domain part", value: "test@domain-" },
+		{ name: "Invalid characters in domain part", value: "test@doma_in.com" },
+		{ name: "Non-Latin characters #1", value: "тест@домен.com" },
+		{ name: "Non-Latin characters in domain part", value: "屁股@混蛋.中国" },
+	];
+
+	for (const testCase of invalidEmailTests) {
+		test(testCase.name, async ({ api, validUser }) => {
+			await expectRegistrationError(
+				api,
+				testCase.value,
+				validUser.name,
+				validUser.password,
+				422,
+				"Invalid email format",
+			);
+		});
+	}
+});
+
+test("[CHECKLY-4] Registration fails when email field is empty", async ({
+	api,
+	validUser,
+}) => {
+	await expectRegistrationError(
+		api,
+		"",
+		validUser.name,
+		validUser.password,
+		422,
+		"Field is required",
+	);
+});
+
+test.describe("[CHECKLY-5] Registration fails when name as an invalid value", () => {
+	const invalidNameTests = [
+		{ name: "Name is empty", value: "", errorMessage: "Field is required" },
+		{
+			name: "Name is too short (less than 3 characters)",
+			value: "Ma",
+			errorMessage:
+				"Name must have at least 3 characters and maximum of 32 characters",
+		},
+		{
+			name: "Name is too long (more than 32 characters)",
+			value: "a".repeat(33),
+			errorMessage:
+				"Name must have at least 3 characters and maximum of 32 characters",
+		},
+		{
+			name: "Space as first character",
+			value: " Max",
+			errorMessage:
+				"Spaces and hyphens are allowed, as long as they are surrounded by letters",
+		},
+		{
+			name: "Space as last character",
+			value: "Max ",
+			errorMessage:
+				"Spaces and hyphens are allowed, as long as they are surrounded by letters",
+		},
+		{
+			name: "Hyphen as first character",
+			value: "-Max",
+			errorMessage:
+				"Spaces and hyphens are allowed, as long as they are surrounded by letters",
+		},
+		{
+			name: "Hyphen as last character",
+			value: "Max-",
+			errorMessage:
+				"Spaces and hyphens are allowed, as long as they are surrounded by letters",
+		},
+		{
+			name: "Invalid Characters #1 - Non Latin Characters",
+			value: "Максим",
+			errorMessage: "Digits and special characters are not allowed",
+		},
+		{
+			name: "Invalid Characters #2 - Special Characters",
+			value: "Max #Mustermann",
+			errorMessage: "Digits and special characters are not allowed",
+		},
+		{
+			name: "Invalid Characters #3 - Digits",
+			value: "Max123",
+			errorMessage: "Digits and special characters are not allowed",
+		},
+	];
+
+	for (const testCase of invalidNameTests) {
+		test(testCase.name, async ({ api, validUser }) => {
+			await expectRegistrationError(
+				api,
+				validUser.email,
+				testCase.value,
+				validUser.password,
+				422,
+				testCase.errorMessage,
+			);
+		});
+	}
+});
+
+test.describe("[CHECKLY-6] Registration fails with empty or weak password", () => {
+	const invalidPasswordTests = [
+		{ name: "Password is empty", value: "", errorMessage: "Field is required" },
+		{
+			name: "Password is too short (less than 8 characters)",
+			value: "12345Ab",
+			errorMessage:
+				"Password should contain between 8 to 32 characters, at least one lowercase letter, one uppercase letter and one digit",
+		},
+		{
+			name: "Password is too long (more than 32 characters)",
+			value: "1A" + "a".repeat(31),
+			errorMessage:
+				"Password should contain between 8 to 32 characters, at least one lowercase letter, one uppercase letter and one digit",
+		},
+		{
+			name: "Password does not contain lowercase letter",
+			value: "123456AB",
+			errorMessage:
+				"Password should contain between 8 to 32 characters, at least one lowercase letter, one uppercase letter and one digit",
+		},
+		{
+			name: "Password does not contain uppercase letter",
+			value: "123456ab",
+			errorMessage:
+				"Password should contain between 8 to 32 characters, at least one lowercase letter, one uppercase letter and one digit",
+		},
+		{
+			name: "Password does not contain digit",
+			value: "Abcdefgh",
+			errorMessage:
+				"Password should contain between 8 to 32 characters, at least one lowercase letter, one uppercase letter and one digit",
+		},
+	];
+
+	for (const testCase of invalidPasswordTests) {
+		test(testCase.name, async ({ api, validUser }) => {
+			await expectRegistrationError(
+				api,
+				validUser.email,
+				validUser.name,
+				testCase.value,
+				422,
+				testCase.errorMessage,
+			);
+		});
+	}
+});

--- a/packages/testing/tests/api/controllers/api-controllers.ts
+++ b/packages/testing/tests/api/controllers/api-controllers.ts
@@ -1,0 +1,10 @@
+import { APIRequestContext } from "@playwright/test";
+import { AuthController } from "./auth-controller";
+
+export class ApiControllers {
+	public readonly auth: AuthController;
+
+	constructor(request: APIRequestContext) {
+		this.auth = new AuthController(request);
+	}
+}

--- a/packages/testing/tests/api/controllers/auth-controller.ts
+++ b/packages/testing/tests/api/controllers/auth-controller.ts
@@ -1,0 +1,44 @@
+import { APIRequestContext, APIResponse } from "@playwright/test";
+
+export class AuthController {
+	constructor(private requestContext: APIRequestContext) {}
+
+	async login(email: string, password: string): Promise<APIResponse> {
+		const response = await this.requestContext.post("auth/login", {
+			data: {
+				email,
+				password,
+			},
+		});
+
+		return response;
+	}
+
+	async register(
+		email: string,
+		name: string,
+		password: string,
+	): Promise<APIResponse> {
+		const response = await this.requestContext.post("auth/register", {
+			data: {
+				email,
+				name,
+				password,
+			},
+		});
+
+		return response;
+	}
+
+	async authMe(token: string): Promise<APIResponse> {
+		const response = await this.requestContext.get("auth/me", {
+			headers: token
+				? {
+						Authorization: `Bearer ${token}`,
+					}
+				: {},
+		});
+
+		return response;
+	}
+}

--- a/packages/testing/tests/api/fixtures/base-fixtures.ts
+++ b/packages/testing/tests/api/fixtures/base-fixtures.ts
@@ -1,0 +1,11 @@
+import { test as baseTest } from "@playwright/test";
+import { ApiControllers } from "@tests/api/controllers/api-controllers";
+
+export const test = baseTest.extend<{
+	api: ApiControllers;
+}>({
+	api: async ({ request }, use) => {
+		const api = new ApiControllers(request);
+		await use(api);
+	},
+});

--- a/packages/testing/tests/api/fixtures/sign-up-fixtures.ts
+++ b/packages/testing/tests/api/fixtures/sign-up-fixtures.ts
@@ -1,0 +1,10 @@
+import { test as baseTest } from "./base-fixtures";
+import { generateUser } from "@test-helpers-api/generators";
+
+export const test = baseTest.extend<{
+	validUser: ReturnType<typeof generateUser>;
+}>({
+	validUser: async ({}, use) => {
+		await use(generateUser());
+	},
+});

--- a/packages/testing/tests/api/helpers/auth-test-helpers.ts
+++ b/packages/testing/tests/api/helpers/auth-test-helpers.ts
@@ -1,0 +1,106 @@
+import { expect } from "@playwright/test";
+
+import { ApiControllers } from "@tests/api/controllers/api-controllers";
+import {
+	registerResponseSchema,
+	loginResponseSchema,
+	authMeSchema,
+} from "@tests/api/schemas/auth-schemas";
+import { errorSchema } from "@tests/api/schemas/error-schemas";
+import { expectToMatchSchema } from "@test-helpers-api/schema-validator";
+
+export async function expectSuccessfulRegistration(
+	api: ApiControllers,
+	email: string,
+	name: string,
+	password: string,
+) {
+	const response = await api.auth.register(email, name, password);
+	const responseBody = await response.json();
+
+	expect(response.status(), "Status Code should be 201").toBe(201);
+	expectToMatchSchema(responseBody, registerResponseSchema);
+
+	return { response, responseBody };
+}
+
+export async function expectRegistrationError(
+	api: ApiControllers,
+	email: string,
+	name: string,
+	password: string,
+	expectedStatus: number,
+	expectedMessage?: string,
+) {
+	const response = await api.auth.register(email, name, password);
+	const responseBody = await response.json();
+
+	expect(response.status()).toBe(expectedStatus);
+	expectToMatchSchema(responseBody, errorSchema);
+
+	if (expectedMessage) {
+		expect(responseBody.message).toBe(expectedMessage);
+	}
+
+	return { response, responseBody };
+}
+
+export async function expectSuccessfulLogin(
+	api: ApiControllers,
+	email: string,
+	password: string,
+) {
+	const response = await api.auth.login(email, password);
+	const responseBody = await response.json();
+
+	expect(response.status(), "Status Code should be 200").toBe(200);
+	expectToMatchSchema(responseBody, loginResponseSchema);
+
+	return { response, responseBody };
+}
+
+export async function expectLoginError(
+	api: ApiControllers,
+	email: string,
+	password: string,
+	expectedStatus: number,
+	expectedMessage?: string,
+) {
+	const response = await api.auth.login(email, password);
+	const responseBody = await response.json();
+
+	expect(response.status()).toBe(expectedStatus);
+	expectToMatchSchema(responseBody, errorSchema);
+
+	if (expectedMessage) {
+		expect(responseBody.message).toBe(expectedMessage);
+	}
+
+	return { response, responseBody };
+}
+
+export async function expectSuccessfulAuthMe(
+	api: ApiControllers,
+	token: string,
+	userId: number,
+) {
+	const response = await api.auth.authMe(token);
+	const responseBody = await response.json();
+
+	expect(response.status(), "Status Code should be 200").toBe(200);
+	expectToMatchSchema(responseBody, authMeSchema);
+	expect(responseBody.id).toBe(userId);
+
+	return { response, responseBody };
+}
+
+export async function expectAuthMeError(api: ApiControllers, token: string) {
+	const response = await api.auth.authMe(token);
+	const responseBody = await response.json();
+
+	expect(response.status(), "Status Code should be 401").toBe(401);
+	expectToMatchSchema(responseBody, errorSchema);
+	expect(responseBody.message).toBe("Authentication failed.");
+
+	return { response, responseBody };
+}

--- a/packages/testing/tests/api/helpers/generators.ts
+++ b/packages/testing/tests/api/helpers/generators.ts
@@ -1,0 +1,27 @@
+import { faker } from "@faker-js/faker";
+
+const generateComplexPassword = (): string => {
+	const length = faker.number.int({ min: 8, max: 32 });
+	const lowercase = faker.string.alpha({ length: 1, casing: "lower" });
+	const uppercase = faker.string.alpha({ length: 1, casing: "upper" });
+	const digit = faker.string.numeric(1);
+	const remaining = faker.internet.password({
+		length: length - 3,
+		memorable: false,
+		pattern: /[a-zA-Z0-9!@#$%^&*]/,
+	});
+
+	const chars = (lowercase + uppercase + digit + remaining).split("");
+	return faker.helpers.shuffle(chars).join("");
+};
+
+export const generateUser = () => {
+	return {
+		email: faker.internet.email(),
+		password: generateComplexPassword(),
+		name: `${faker.person.firstName()} ${faker.person.lastName()}`.replace(
+			"'",
+			"",
+		),
+	};
+};

--- a/packages/testing/tests/api/helpers/schema-validator.ts
+++ b/packages/testing/tests/api/helpers/schema-validator.ts
@@ -1,0 +1,15 @@
+import Ajv from "ajv";
+import { expect } from "@playwright/test";
+
+const ajv = new Ajv({ strict: false });
+
+export function expectToMatchSchema(responseBody: any, schema: object) {
+	const validate = ajv.compile(schema);
+	const valid = validate(responseBody);
+
+	expect(valid, "Response should match schema").toBe(true);
+
+	if (!valid) {
+		console.log("Schema errors:", validate.errors);
+	}
+}

--- a/packages/testing/tests/api/schemas/auth-schemas.ts
+++ b/packages/testing/tests/api/schemas/auth-schemas.ts
@@ -1,0 +1,40 @@
+export const registerResponseSchema = {
+	type: "object",
+	properties: {
+		user: {
+			type: "object",
+			properties: {
+				id: { type: "number" },
+				email: { type: "string" },
+				name: { type: "string" },
+			},
+		},
+		token: { type: "string" },
+	},
+	required: ["user", "token"],
+};
+
+export const loginResponseSchema = {
+	type: "object",
+	properties: {
+		user: {
+			type: "object",
+			properties: {
+				email: { type: "string" },
+				password: { type: "string" },
+			},
+		},
+		token: { type: "string" },
+	},
+	required: ["user", "token"],
+};
+
+export const authMeSchema = {
+	type: "object",
+	properties: {
+		id: { type: "number" },
+		email: { type: "string" },
+		name: { type: "string" },
+	},
+	required: ["id", "email", "name"],
+};

--- a/packages/testing/tests/api/schemas/error-schemas.ts
+++ b/packages/testing/tests/api/schemas/error-schemas.ts
@@ -1,0 +1,8 @@
+export const errorSchema = {
+	type: "object",
+	properties: {
+		errorType: { type: "string" },
+		message: { type: "string" },
+	},
+	required: ["errorType", "message"],
+};

--- a/packages/testing/tests/ui/auth/sign-in.ui.spec.ts
+++ b/packages/testing/tests/ui/auth/sign-in.ui.spec.ts
@@ -1,0 +1,229 @@
+import { test as base, expect as baseExpect } from "@playwright/test";
+import { test, expect } from "@ui/fixtures/user.fixture";
+import { SignInPage } from "@tests/ui/controllers/sign-in-page";
+import { signUpUser } from "@ui/helpers/auth";
+
+test.describe("[Sign in - UI] Consolidated suite", () => {
+	test.afterEach(async ({ page }) => {
+		// Refresh between tests as requested
+		await page.reload();
+	});
+
+	test("[Sign in - UI] All required fields are visible and properly configured", async ({
+		page,
+	}) => {
+		const signInPage = new SignInPage(page);
+		await signInPage.goto();
+
+		await expect(signInPage.emailInput).toBeVisible();
+		await expect(signInPage.emailInput).toHaveAttribute("type", "email");
+		await expect(signInPage.emailInput).toHaveAttribute(
+			"placeholder",
+			"Enter your email",
+		);
+
+		await expect(signInPage.passwordInput).toBeVisible();
+		await expect(signInPage.passwordInput).toHaveAttribute("type", "password");
+		await expect(signInPage.passwordInput).toHaveAttribute(
+			"placeholder",
+			"Enter your password",
+		);
+
+		await expect(signInPage.submitButton).toBeVisible();
+	});
+
+	test.describe("[Sign In - UI] Form validation highlights required fields", () => {
+		test.beforeEach(async ({ page }) => {
+			const signInPage = new SignInPage(page);
+			await signInPage.goto();
+		});
+
+		test("Should mark both email and password as invalid when both are empty", async ({
+			page,
+		}) => {
+			const signInPage = new SignInPage(page);
+			await signInPage.submit();
+
+			const invalidInputs = signInPage.page.locator("input:invalid");
+			await expect(invalidInputs).toHaveCount(2);
+		});
+
+		test("Should mark email as invalid when only password is filled", async ({
+			page,
+		}) => {
+			const signInPage = new SignInPage(page);
+			await signInPage.passwordInput.fill("SomePassword123");
+			await signInPage.submit();
+
+			const invalidInputs = signInPage.page.locator("input:invalid");
+			await expect(invalidInputs).toHaveCount(1);
+			await expect(invalidInputs.first()).toHaveAttribute("name", "email");
+		});
+
+		test("Should mark password as invalid when only email is filled", async ({
+			page,
+		}) => {
+			const signInPage = new SignInPage(page);
+			await signInPage.emailInput.fill("user@example.com");
+			await signInPage.submit();
+
+			const invalidInputs = signInPage.page.locator("input:invalid");
+			await expect(invalidInputs).toHaveCount(1);
+			await expect(invalidInputs.first()).toHaveAttribute("name", "password");
+		});
+	});
+
+	test.describe("[Sign In - UI] Invalid email format blocks submission (backend validation)", () => {
+		const invalidEmails = [
+			"emoji😊@invalid-characters.com",
+			"测试电子邮件@invalid-characters.com",
+			"invalid-format.com",
+			".localstartswithdot@test.com",
+			"localendswithdot.@test.com",
+			"repeated..dots@test.com",
+			"valid@-domainstartswithhyphen.com",
+			"valid@domainendswithhyphen-.com",
+			"valid@.domainstartswithdot.com",
+			"valid@domainendswithdot.com.",
+		];
+
+		for (const email of invalidEmails) {
+			test(`Should show backend error for invalid email: ${email}`, async ({
+				page,
+			}) => {
+				const signInPage = new SignInPage(page);
+				await signInPage.goto();
+
+				await signInPage.fillForm(email, "ValidPassword123");
+				await signInPage.submit();
+
+				// Retry-safe backend error validation
+				await expect(signInPage.emailErrorMessage).toBeVisible({
+					timeout: 10000,
+				});
+
+				// Assert user is still on Sign In page
+				await expect(page).toHaveURL(/sign-in/);
+			});
+		}
+	});
+
+	test.describe("[Sign In - UI] Invalid password format blocks submission (backend validation)", () => {
+		const invalidPasswords = [
+			{ password: "Pa1", reason: "too short" },
+			{ password: "password1", reason: "no uppercase" },
+			{ password: "PASSWORD1", reason: "no lowercase" },
+			{ password: "Password", reason: "no digits" },
+			{
+				password: "Password1234567891011121314151617181920",
+				reason: "too long",
+			},
+			{ password: "Password 1", reason: "contains space" },
+		];
+
+		test.beforeEach(async ({ page }) => {
+			const signInPage = new SignInPage(page);
+			await signInPage.goto();
+		});
+
+		for (const { password, reason } of invalidPasswords) {
+			test(`Should show backend error for password with issue: ${reason}`, async ({
+				page,
+			}) => {
+				const signInPage = new SignInPage(page);
+				await signInPage.fillForm("user@example.com", password);
+				await signInPage.submit();
+
+				const error = signInPage.page.getByText(
+					/Password should contain between 8 to 32 characters, at least one lowercase letter, one uppercase letter and one digit/i,
+				);
+				await expect(error).toBeVisible({ timeout: 5000 });
+			});
+		}
+	});
+
+	test.describe("[Sign In - UI] Shows error for invalid credentials", () => {
+		test.beforeEach(async ({ page }) => {
+			const signInPage = new SignInPage(page);
+			await signInPage.goto();
+		});
+
+		test("Displays error when credentials are invalid", async ({ page }) => {
+			const signInPage = new SignInPage(page);
+			await signInPage.fillForm("sadasdas@asdasd.com", "WrongPassword123");
+			await signInPage.submit();
+
+			await expect(signInPage.errorMessage).toBeVisible();
+		});
+	});
+
+	test.describe("[Sign In - UI] Unsuccessful login - incorrect password", () => {
+		test('Shows "Invalid credentials" when password is wrong', async ({
+			page,
+		}) => {
+			const email = "test@email.com";
+			const correctPassword = "CorrectPass123";
+			const wrongPassword = "WrongPass123";
+
+			// Arrange: create a valid user via API
+			await signUpUser(email, correctPassword);
+
+			// Act: attempt login with wrong password
+			const signIn = new SignInPage(page);
+			await signIn.goto();
+			await signIn.fillForm(email, wrongPassword);
+			await signIn.submit();
+
+			// Assert: toast/banner should show the generic error
+			await expect(signIn.errorMessage).toBeVisible();
+		});
+	});
+
+	test.describe("[Sign in - UI] Successful login redirects to dashboard", () => {
+		test("Redirects to dashboard on successful login", async ({
+			page,
+			testUser,
+		}) => {
+			// Act: perform sign in with valid credentials
+			const signIn = new SignInPage(page);
+			await signIn.goto();
+			await signIn.fillForm(testUser.email, testUser.password);
+			await signIn.submit();
+
+			// Assert #1: user is redirected to /dashboard
+			await expect(page).toHaveURL(/\/dashboard\/?$/);
+
+			// Assert #2: dashboard-specific content is visible
+			await expect(
+				page.getByRole("navigation").getByRole("link", { name: /^Dashboard$/ }),
+			).toBeVisible();
+			await expect(
+				page.getByRole("navigation").getByRole("link", { name: /My plan/i }),
+			).toBeVisible();
+
+			// Assert #3 (optional): sign-in form is no longer present
+			await expect(page.getByRole("button", { name: /sign in/i })).toHaveCount(
+				0,
+			);
+		});
+	});
+
+	test.describe("[Sign in - UI] Deep link protection", () => {
+		test("Redirects unauthenticated users to sign-in and back to intended route after login", async ({
+			page,
+			testUser,
+		}) => {
+			// Step 1: Visit a protected page without being signed in
+			await page.goto("/dashboard");
+			await expect(page).toHaveURL(/\/sign-in\/?$/);
+
+			// Step 2: Sign in
+			const signIn = new SignInPage(page);
+			await signIn.fillForm(testUser.email, testUser.password);
+			await signIn.submit();
+
+			// Step 3: Validate user lands on intended protected route
+			await expect(page).toHaveURL(/\/dashboard\/?$/);
+		});
+	});
+});

--- a/packages/testing/tests/ui/auth/sign-up.ui.spec.ts
+++ b/packages/testing/tests/ui/auth/sign-up.ui.spec.ts
@@ -1,0 +1,226 @@
+// tests/ui/auth/sign-up.ui.spec.ts
+import { test, expect } from "@ui/fixtures/user.fixture";
+import { signUpUser } from "@ui/helpers/auth";
+import { SignUpPage } from "@tests/ui/controllers/sign-up-page";
+import {
+	uniqueEmail,
+	validPassword,
+	randomName,
+} from "@tests/ui/helpers/user-data";
+
+test.describe("[Sign up - UI] Consolidated suite", () => {
+	test.afterEach(async ({ page }) => {
+		// Explicit refresh between tests (isolation already exists, but requested)
+		await page.reload();
+	});
+
+	// 1) Required elements are visible and typed correctly
+	test("[Sign up - UI] All required form elements are visible and properly configured", async ({
+		page,
+	}) => {
+		const signUp = new SignUpPage(page);
+		await signUp.goto();
+		await signUp.validateRequiredFieldsVisibleAndTyped();
+	});
+
+	// 2) Required-field behavior (prevent submission with missing inputs)
+	test.describe("[Sign up - UI] Fields are marked as required", () => {
+		test.beforeEach(async ({ page }) => {
+			const signUp = new SignUpPage(page);
+			await signUp.goto();
+		});
+
+		test("Blocks submission when all fields are empty", async ({ page }) => {
+			const signUp = new SignUpPage(page);
+			await signUp.submit();
+			await signUp.expectOnRegisterUrl();
+			await expect(page.locator("input:invalid").first()).toBeVisible();
+		});
+
+		test("Blocks submission when only Name is filled", async ({ page }) => {
+			const signUp = new SignUpPage(page);
+			await signUp.fillName(randomName());
+			await signUp.submit();
+			await signUp.expectOnRegisterUrl();
+			await expect(page.locator("input:invalid").first()).toBeVisible();
+		});
+
+		test("Blocks submission when Email is filled but Password empty", async ({
+			page,
+		}) => {
+			const signUp = new SignUpPage(page);
+			await signUp.fillName(randomName());
+			await signUp.fillEmail(uniqueEmail());
+			await signUp.submit();
+			await signUp.expectOnRegisterUrl();
+			await expect(page.locator("input:invalid").first()).toBeVisible();
+		});
+
+		test("Blocks submission when Password is filled but Confirm Password empty", async ({
+			page,
+		}) => {
+			const signUp = new SignUpPage(page);
+			await signUp.fillName(randomName());
+			await signUp.fillEmail(uniqueEmail());
+			await signUp.fillPassword("Password123");
+			await signUp.submit();
+			await signUp.expectOnRegisterUrl();
+			await expect(page.locator("input:invalid").first()).toBeVisible();
+		});
+	});
+
+	// 3) Happy path – successful submission
+	test.describe("[Sign up - UI] Successful form submission redirects or shows success message", () => {
+		// Run multiple times to mimic parametrized data from the JSON using faker-backed helpers
+		for (let i = 0; i < 6; i++) {
+			test(`Succeeds with valid, faker-generated data #${i + 1}`, async ({
+				page,
+			}) => {
+				const signUp = new SignUpPage(page);
+				await signUp.goto();
+
+				const name = randomName();
+				const email = uniqueEmail();
+				const password = validPassword();
+
+				await signUp.fillForm({
+					name,
+					email,
+					password,
+					confirmPassword: password,
+				});
+				await signUp.submit();
+				await signUp.expectSuccessRedirect();
+			});
+		}
+	});
+
+	// 4) Already-registered email error
+	test("[Sign up - UI] Attempt to register with an already registered email", async ({
+		page,
+	}) => {
+		const email = uniqueEmail();
+		const password = validPassword();
+		const name = randomName();
+
+		// Pre-create the account through API; tolerate existing to keep test idempotent
+		await signUpUser(email, password, name, { tolerateExisting: true });
+
+		const signUp = new SignUpPage(page);
+		await signUp.goto();
+		await signUp.fillForm({ name, email, password, confirmPassword: password });
+		await signUp.submit();
+
+		await expect(signUp.emailInUseError).toBeVisible({ timeout: 10000 });
+		await signUp.expectOnRegisterUrl();
+	});
+
+	// 5) Mismatched password confirmation
+	test("[Sign up - UI] Password and confirm password must match", async ({
+		page,
+	}) => {
+		const signUp = new SignUpPage(page);
+		await signUp.goto();
+
+		await signUp.fillForm({
+			name: randomName(),
+			email: uniqueEmail(),
+			password: "Password123",
+			confirmPassword: "Password456",
+		});
+		await signUp.submit();
+
+		await signUp.expectOnRegisterUrl();
+		await expect(signUp.passwordMismatchError).toBeVisible();
+	});
+
+	// 6) Invalid email format matrix (static negative samples are acceptable)
+	test.describe("[Sign up - UI] Shows error when email format is invalid", () => {
+		const invalidEmails = [
+			"plainaddress",
+			"@missinglocal.com",
+			"user@",
+			".user@domain.com",
+			"user.@domain.com",
+			"user@-domain.com",
+			"user@domain-.com",
+			"user@domain..com",
+			"user@.domain.com",
+			"user@domain_.com",
+		];
+
+		invalidEmails.forEach((badEmail, idx) => {
+			test(`Invalid email format #${idx + 1}: ${badEmail}`, async ({
+				page,
+			}) => {
+				const signUp = new SignUpPage(page);
+				await signUp.goto();
+
+				await signUp.fillForm({
+					name: randomName(),
+					email: badEmail,
+					password: "Password123",
+					confirmPassword: "Password123",
+				});
+				await signUp.submit();
+
+				await signUp.expectOnRegisterUrl();
+				await expect(signUp.emailFormatError).toBeVisible({ timeout: 10000 });
+			});
+		});
+	});
+
+	// 7) Weak/invalid password matrix (static negative samples accepted)
+	test.describe("[Sign up - UI] Shows error when password is weak or invalid", () => {
+		const weakPasswords = [
+			"short1A", // too short
+			"nouppercase123", // no uppercase
+			"NOLOWERCASE123,", // no lowercase (includes comma)
+			"NoDigitsHere!", // no digits
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1a", // > 32 chars
+		];
+
+		weakPasswords.forEach((pwd, idx) => {
+			test(`Weak/invalid password #${idx + 1}`, async ({ page }) => {
+				const signUp = new SignUpPage(page);
+				await signUp.goto();
+
+				await signUp.fillForm({
+					name: randomName(),
+					email: uniqueEmail(),
+					password: pwd,
+					confirmPassword: pwd,
+				});
+				await signUp.submit();
+
+				await signUp.expectOnRegisterUrl();
+				await expect(signUp.passwordPolicyError).toBeVisible({
+					timeout: 10000,
+				});
+			});
+		});
+	});
+
+	// 8) Invalid name length (static edge cases)
+	test.describe("[Sign up - UI] Registration fails when name has invalid length", () => {
+		const badNames = ["Vi", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"]; // <3 and >32
+
+		badNames.forEach((badName, idx) => {
+			test(`Invalid name length #${idx + 1}`, async ({ page }) => {
+				const signUp = new SignUpPage(page);
+				await signUp.goto();
+
+				await signUp.fillForm({
+					name: badName,
+					email: uniqueEmail(),
+					password: "Password123",
+					confirmPassword: "Password123",
+				});
+				await signUp.submit();
+
+				await signUp.expectOnRegisterUrl();
+				await expect(signUp.nameLengthError).toBeVisible({ timeout: 10000 });
+			});
+		});
+	});
+});

--- a/packages/testing/tests/ui/controllers/landing-navigation.ts
+++ b/packages/testing/tests/ui/controllers/landing-navigation.ts
@@ -1,0 +1,57 @@
+import { test as base, Locator, Page } from "@playwright/test";
+
+//export Locators for each segment of the page. Using "sectionSection" format for segments that have the <section> tag
+export const test = base.extend<{
+	page: Page;
+	header: Locator;
+	heroSection: Locator;
+	howItWorksSection: Locator;
+	categoriesSection: Locator;
+	layoutsSection: Locator;
+	testimonialsSection: Locator;
+	footer: Locator;
+}>({
+	page: async ({ page }, use) => {
+		await page.goto("/");
+		await use(page);
+	},
+
+	header: async ({ page }, use) => {
+		const section = page.locator("header");
+		await use(section);
+	},
+
+	heroSection: async ({ page }, use) => {
+		const section = page.locator("section", {
+			hasText: /^create a personal development plan/i,
+		});
+		await use(section);
+	},
+
+	howItWorksSection: async ({ page }, use) => {
+		const section = page.locator("section", { hasText: /^how it works/i });
+		await use(section);
+	},
+
+	categoriesSection: async ({ page }, use) => {
+		const section = page.locator("section", { hasText: /^categories/i });
+		await use(section);
+	},
+
+	layoutsSection: async ({ page }, use) => {
+		const section = page.locator("section", {
+			hasText: /^Sample visual layouts/i,
+		});
+		await use(section);
+	},
+
+	testimonialsSection: async ({ page }, use) => {
+		const section = page.locator("section", { hasText: /^testimonials/i });
+		await use(section);
+	},
+
+	footer: async ({ page }, use) => {
+		const footer = page.locator("footer");
+		await use(footer);
+	},
+});

--- a/packages/testing/tests/ui/controllers/sign-In-page.ts
+++ b/packages/testing/tests/ui/controllers/sign-In-page.ts
@@ -1,0 +1,36 @@
+import { Page, Locator } from "@playwright/test";
+
+export class SignInPage {
+	readonly page: Page;
+	readonly emailInput: Locator;
+	readonly passwordInput: Locator;
+	readonly submitButton: Locator;
+	readonly linkToSignUp: Locator;
+	readonly emailErrorMessage: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.emailInput = page.getByPlaceholder("Enter your email");
+		this.passwordInput = page.getByPlaceholder("Enter your password");
+		this.submitButton = page.getByRole("button", { name: /sign in/i });
+		this.linkToSignUp = page.getByRole("link", { name: /create an account/i });
+		this.emailErrorMessage = page.getByText(/invalid email format/i);
+	}
+
+	async goto() {
+		await this.page.goto("/sign-in");
+	}
+
+	get errorMessage() {
+		return this.page.getByText(/invalid credentials/i);
+	}
+
+	async fillForm(email: string, password: string) {
+		await this.emailInput.fill(email);
+		await this.passwordInput.fill(password);
+	}
+
+	async submit() {
+		await this.submitButton.click();
+	}
+}

--- a/packages/testing/tests/ui/controllers/sign-up-page.ts
+++ b/packages/testing/tests/ui/controllers/sign-up-page.ts
@@ -1,0 +1,157 @@
+import { Page, Locator, expect } from "@playwright/test";
+
+/**
+ * SignUpPage POM
+ * - Accessible-first locators (roles + accessible names) matching your JSX.
+ * - Defensive navigation to /sign-up with form readiness check.
+ * - Tolerant field-type validation (email input is type="text" in your form).
+ */
+export class SignUpPage {
+	readonly page: Page;
+
+	// Inputs
+	readonly nameInput: Locator;
+	readonly emailInput: Locator;
+	readonly passwordInput: Locator;
+	readonly confirmPasswordInput: Locator;
+
+	// Actions
+	readonly submitButton: Locator;
+
+	// Inline errors (copy-tolerant)
+	readonly emailInUseError: Locator;
+	readonly emailFormatError: Locator;
+	readonly passwordPolicyError: Locator;
+	readonly passwordMismatchError: Locator;
+	readonly nameLengthError: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+
+		// Match <Input label="..."> components rendered as textboxes with those labels
+		this.nameInput = page.getByRole("textbox", { name: /^Name$/i });
+		this.emailInput = page.getByRole("textbox", { name: /^Email$/i });
+		this.passwordInput = page
+			.getByRole("textbox", { name: /^Password$/i })
+			.first(); // main password
+		this.confirmPasswordInput = page.getByRole("textbox", {
+			name: /Confirm password/i,
+		});
+
+		// Match <Button label="Create an account">
+		this.submitButton = page.getByRole("button", {
+			name: /create an account/i,
+		});
+
+		// Error messages (kept flexible for minor copy changes)
+		this.emailInUseError = page.getByText(/email already in use/i);
+		this.emailFormatError = page.getByText(
+			/email is not in a valid format|invalid email/i,
+		);
+		this.passwordPolicyError = page.getByText(
+			/password should contain between 8 to 32 characters, at least one lowercase letter, one uppercase letter and one digit/i,
+		);
+		this.passwordMismatchError = page.getByText(
+			/passwords (do\s*not|don['’]t) match/i,
+		);
+		this.nameLengthError = page.getByText(
+			/name\s+must\s+(?:be\s+between\s+3\s+and\s+32|have\s+at\s+least\s+3\s+characters\s+and\s+maximum\s+of\s+32)\s+characters/i,
+		);
+	}
+
+	/** Navigate to the sign-up screen and wait until the form is ready */
+	async goto() {
+		await this.page.goto("/sign-up", { waitUntil: "domcontentloaded" });
+		await expect(this.page).toHaveURL(/\/sign-up\/?$/);
+		await this.submitButton.waitFor({ state: "visible" });
+	}
+
+	// ---------- Fill helpers ----------
+
+	async fillName(value: string) {
+		await this.nameInput.fill(value);
+	}
+	async fillEmail(value: string) {
+		await this.emailInput.fill(value);
+	}
+	async fillPassword(value: string) {
+		await this.passwordInput.fill(value);
+	}
+	async fillConfirmPassword(value: string) {
+		await this.confirmPasswordInput.fill(value);
+	}
+
+	async fillForm(params: {
+		name?: string;
+		email?: string;
+		password?: string;
+		confirmPassword?: string;
+	}) {
+		const { name, email, password, confirmPassword } = params;
+		if (name !== undefined) await this.fillName(name);
+		if (email !== undefined) await this.fillEmail(email);
+		if (password !== undefined) await this.fillPassword(password);
+		if (confirmPassword !== undefined)
+			await this.fillConfirmPassword(confirmPassword);
+	}
+
+	async submit() {
+		await this.submitButton.click();
+	}
+
+	/** Expect to still be on the sign-up page (used by negative cases) */
+	async expectOnRegisterUrl() {
+		await expect(this.page).toHaveURL(/\/sign-up\/?$/);
+	}
+
+	/** Accept either redirect to sign-in or to dashboard after success */
+	async expectSuccessRedirect() {
+		await expect(this.page).toHaveURL(/\/(sign-in|dashboard)\/?$/);
+	}
+
+	/**
+	 * Sanity: required fields are visible and typed.
+	 * - Name: JS property 'type' must be 'text' (attribute may be omitted).
+	 * - Email: accept 'text' OR 'email' (your form uses type="text").
+	 * - Passwords: if 'type' attribute exists, it must be 'password'.
+	 */
+	async validateRequiredFieldsVisibleAndTyped() {
+		await expect(
+			this.page.getByRole("form", { name: /create an account/i }),
+		).toBeVisible();
+
+		// Name
+		await expect(this.nameInput).toBeVisible();
+		await expect.soft(this.nameInput).toHaveJSProperty("type", "text");
+
+		// Email (tolerate 'text' or 'email')
+		await expect(this.emailInput).toBeVisible();
+		const emailType = (
+			await this.emailInput.getAttribute("type")
+		)?.toLowerCase();
+		if (emailType) {
+			expect.soft(["email", "text"]).toContain(emailType);
+		}
+
+		// Password
+		await expect(this.passwordInput).toBeVisible();
+		const pwdType = (
+			await this.passwordInput.getAttribute("type")
+		)?.toLowerCase();
+		if (pwdType) {
+			expect.soft(pwdType).toBe("password");
+		}
+
+		// Confirm password
+		await expect(this.confirmPasswordInput).toBeVisible();
+		const cpwdType = (
+			await this.confirmPasswordInput.getAttribute("type")
+		)?.toLowerCase();
+		if (cpwdType) {
+			expect.soft(cpwdType).toBe("password");
+		}
+
+		// Submit button
+		await expect(this.submitButton).toBeVisible();
+	}
+}

--- a/packages/testing/tests/ui/fixtures/user.fixture.ts
+++ b/packages/testing/tests/ui/fixtures/user.fixture.ts
@@ -1,0 +1,27 @@
+import { test as base, expect } from "@playwright/test";
+import { signUpUser } from "../helpers/auth";
+
+type UserFixture = {
+	email: string;
+	password: string;
+};
+
+export const test = base.extend<{}, { testUser: UserFixture }>({
+	// Note: The second generic parameter is for "worker" fixtures
+	testUser: [
+		async ({}, use) => {
+			const email = "ui-test-user@email.com";
+			const password = "CorrectPass123";
+
+			// Create the user once per worker, tolerate if already exists
+			await signUpUser(email, password, "Test User", {
+				tolerateExisting: true,
+			});
+
+			await use({ email, password });
+		},
+		{ scope: "worker" },
+	],
+});
+
+export { expect };

--- a/packages/testing/tests/ui/helpers/auth.ts
+++ b/packages/testing/tests/ui/helpers/auth.ts
@@ -1,0 +1,47 @@
+type SignUpOptions = {
+	// When true, do not throw if the email is already registered (default: true)
+	tolerateExisting?: boolean;
+};
+
+export async function signUpUser(
+	email: string,
+	password: string,
+	name = "Test User",
+	opts: SignUpOptions = { tolerateExisting: true },
+) {
+	const url = `${process.env.API_URL}auth/register`;
+
+	// Sanitize name: allow only letters and spaces (backend forbids digits/special chars)
+	const safeName =
+		name
+			.replace(/[^A-Za-z\s]/g, " ")
+			.replace(/\s+/g, " ")
+			.trim() || "Test User";
+
+	const res = await fetch(url, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({ email, name: safeName, password }),
+	});
+
+	if (res.ok) return;
+
+	const status = res.status;
+	const text = await res.text();
+
+	// Tolerate "already exists" cases even if backend returns 400 or 500
+	try {
+		const json = JSON.parse(text);
+		const alreadyExists =
+			/email already in use/i.test(String(json?.message)) ||
+			/duplicate key value/i.test(String(json?.message));
+
+		if ((opts.tolerateExisting ?? true) && alreadyExists) {
+			return; // treat as "user is ready"
+		}
+	} catch {
+		// Ignore JSON parse errors; fall through to throw
+	}
+
+	throw new Error(`Sign up failed: ${status} ${text}`);
+}

--- a/packages/testing/tests/ui/helpers/user-data.ts
+++ b/packages/testing/tests/ui/helpers/user-data.ts
@@ -1,0 +1,20 @@
+import { faker } from "@faker-js/faker";
+
+export const uniqueEmail = () => faker.internet.email().toLowerCase();
+
+export const validPassword = (length = 12) => {
+	// Guard length between 8 and 32 as per policy
+	const len = Math.min(32, Math.max(8, length));
+
+	const lower = faker.string.alpha({ length: 1, casing: "lower" });
+	const upper = faker.string.alpha({ length: 1, casing: "upper" });
+	const digit = faker.string.numeric({ length: 1 });
+
+	const remaining = faker.string.alphanumeric({ length: len - 3 });
+
+	const chars = (lower + upper + digit + remaining).split("");
+	return faker.helpers.shuffle(chars).join("");
+};
+
+export const randomName = () =>
+	faker.person.firstName() + " " + faker.person.lastName();

--- a/packages/testing/tests/ui/landing/landing-page.ui.spec.ts
+++ b/packages/testing/tests/ui/landing/landing-page.ui.spec.ts
@@ -1,0 +1,298 @@
+import { test } from "@ui/controllers/landing-navigation";
+import { expect } from "@playwright/test";
+
+test.describe("Page Title", async () => {
+	test("Landing page has Checkly Title", async ({ page }) => {
+		await expect(page).toHaveTitle("Checkly");
+	});
+	// Optional, check the presence of a favicon
+	test.skip("Landing page has a favicon", async ({ page }) => {
+		const favicon = page.locator(
+			'link[rel="icon"][type="image/x-icon"][href="/favicon.ico"]',
+		);
+		await expect(favicon).toHaveCount(1);
+	});
+});
+
+test.describe("Header", async () => {
+	test("header contains page name", async ({ header }) => {
+		await expect(header.getByText("Checkly")).toBeVisible();
+	});
+
+	test("header contains page logo", async ({ header }) => {
+		const headerLogo = header.locator("img");
+		await expect(headerLogo).toBeVisible();
+		await expect(headerLogo).toHaveAttribute(
+			"alt",
+			"Binary Checkly web-application logo",
+		);
+	});
+
+	test("header Start Quiz and Sign in links", async ({ header }) => {
+		await expect(
+			header.getByRole("link", { name: "Start quiz" }),
+		).toBeVisible();
+		await expect(header.getByRole("link", { name: "Sign in" })).toBeVisible();
+	});
+
+	test("Sign in button navigates to the sign-in page", async ({ page }) => {
+		await page.getByRole("link", { name: "Sign in" }).click();
+		const heading = page.getByRole("heading", { name: "Sign In" });
+		await expect(heading).toBeVisible();
+	});
+
+	//Skipping until this function gets implemented.
+	test.skip("Star Quiz button navigates to the sign-up page", async ({
+		page,
+	}) => {
+		await page.getByRole("link", { name: "Sign in" }).click();
+		const heading = page.getByRole("heading", { name: "Sign Up" });
+		await expect(heading).toBeVisible();
+	});
+});
+
+test.describe("Hero", async () => {
+	test("Hero section has heading", async ({ heroSection }) => {
+		const heroHeading = heroSection.getByRole("heading", {
+			name: "Create a personal development plan in 2 minutes",
+		});
+		await expect(heroHeading).toBeVisible();
+	});
+
+	test("Hero section has subtitle", async ({ heroSection }) => {
+		const subtitle = heroSection.getByText(
+			"AI-powered checklist generator for your goals — from fitness to creativity",
+		);
+		await expect(subtitle).toBeVisible();
+	});
+
+	test("Hero section has Start button", async ({ heroSection }) => {
+		const startButton = heroSection.getByRole("link", { name: /^start$/i });
+		await expect(startButton).toBeVisible();
+		await expect(startButton).toHaveAttribute("href", "/");
+	});
+
+	test("Hero section has decorative images", async ({ heroSection }) => {
+		const images = heroSection.locator("img"); //[class^="_icons-wrapper"] can be used for I rather avoid it
+		await expect(images).toHaveCount(5);
+		// await expect(images.nth(0)).toHaveAttribute('alt', ''); Optional for alt attribute
+	});
+
+	//Skipping until behavior is defined and implemented
+	test.skip("Star button redirects to - page", async ({ heroSection }) => {});
+});
+
+test.describe("How it Works", async () => {
+	test("How it Works has a title", async ({ howItWorksSection }) => {
+		const howHeading = howItWorksSection.getByRole("heading", {
+			name: "How it works",
+		});
+		await expect(howHeading).toBeVisible();
+	});
+
+	test("How it Works has 3-step guide", async ({ howItWorksSection }) => {
+		//Only works if they're in order in the html
+		const stepsText = await howItWorksSection.textContent();
+		expect(stepsText).toContain("1");
+		expect(stepsText).toContain("Take the quiz");
+		expect(stepsText).toContain("2");
+		expect(stepsText).toContain("Get your plan");
+		expect(stepsText).toContain("3");
+		expect(stepsText).toContain("Download PDF or customize it");
+
+		//Alternatively:
+		// const steps = [
+		//   { number: '1', title: 'Take the quiz' },
+		//   { number: '2', title: 'Get your plan' },
+		//   { number: '3', title: 'Download PDF or customize it' },
+		// ];
+
+		// for (const { number, title } of steps) {
+		//   const stepNumber = page.locator(`text="${number}"`);
+		//   const stepTitle = page.getByText(title, { exact: true });
+		//   await expect(stepNumber).toBeVisible();
+		//   await expect(stepTitle).toBeVisible();
+		// }
+	});
+
+	test("How it Works has decorative images", async ({ howItWorksSection }) => {
+		const croissantImg = howItWorksSection.locator('img[src*="croissant"]');
+		const laptopImg = howItWorksSection.locator('img[src*="laptop"]');
+
+		await expect(croissantImg).toBeVisible();
+		await expect(laptopImg).toBeVisible();
+
+		const arrows = howItWorksSection.locator('img[class*="arrow"]');
+		const arrowCount = await arrows.count();
+		expect(arrowCount).toBeGreaterThanOrEqual(2);
+	});
+});
+
+test.describe("Categories", async () => {
+	test("Categories has a title", async ({ categoriesSection }) => {
+		const categoriesHeading = categoriesSection.getByRole("heading", {
+			name: "Categories",
+		});
+		await expect(categoriesHeading).toBeVisible();
+	});
+
+	test("Categories has 6 buttons", async ({ categoriesSection }) => {
+		const categoriesButtons = categoriesSection.locator("button");
+		await expect(categoriesButtons).toHaveCount(6);
+	});
+
+	test("Each button has their corresponding name and an image", async ({
+		categoriesSection,
+	}) => {
+		const categoriesButtons = categoriesSection.locator("button");
+		const categoriesTitles = [
+			"personal development",
+			"spirituality",
+			"sport",
+			"money",
+			"creativity",
+			"hobby",
+		];
+
+		for (let i = 0; i < categoriesTitles.length; i++) {
+			const button = categoriesButtons.nth(i);
+			const h2 = button.locator("h3");
+			const img = button.locator("img");
+
+			await expect(h2).toHaveText(categoriesTitles[i]);
+			await expect(img).toBeVisible(); //If alt is added and matches the category, it might be better to instead .toHaveAttribute('alt', categoriesTitles[i]);
+			await expect(button).toHaveAttribute("aria-pressed", /true|false/); //Check if buttons are clickable (optional)
+		}
+	});
+});
+
+test.describe("Layouts", async () => {
+	test("Layouts section has a title", async ({ layoutsSection }) => {
+		const layoutsHeading = layoutsSection.getByRole("heading", {
+			name: "Sample visual layouts",
+		});
+		await expect(layoutsHeading).toBeVisible();
+	});
+
+	test("Layouts has example cards", async ({ layoutsSection }) => {
+		const layoutsCards = layoutsSection.locator("li"); //Alternatively ('[role="listitem"]') could be used if they change the attribute
+		const count = await layoutsCards.count();
+		expect(count).toBeGreaterThan(5);
+	});
+
+	test("Each card has and image and a name", async ({ layoutsSection }) => {
+		const layoutsCards = layoutsSection.locator("li");
+		const count = await layoutsCards.count();
+		for (let i = 0; i < count; i++) {
+			const card = layoutsCards.nth(i);
+			const img = card.locator("img");
+
+			await expect(img).toBeVisible();
+			await expect(card.locator("h5")).toBeVisible();
+		}
+
+		// Optionals: Compare img with alt; aria-label check; match img alt with title. (add to the for loop)
+
+		// await expect(img).toHaveAttribute('alt', /Preview of the/i);
+		// await expect(card).toHaveAttribute('aria-label', /Visual layout option:/i); Optional
+		// await expect(img).toHaveAttribute('alt', /Preview of the/i); Check img alt matches card title
+
+		// Optional: Check each card title by matching their aria-label
+
+		// for (let i = 0; i < count; i++) {
+		//   const card = layoutsCards.nth(i);
+		//   const ariaLabel = await card.getAttribute('aria-label');
+		//   const expectedTitle = ariaLabel?.replace('Visual layout option: ', '').trim();
+		//   const actualTitle = await card.locator('h5').textContent();
+		//   const trimmedTitle = actualTitle?.trim();
+
+		//   expect(trimmedTitle).toBe(expectedTitle);
+		// }
+	});
+});
+
+test.describe("Testimonials", async () => {
+	test("Testimonials section has a title", async ({ testimonialsSection }) => {
+		const testimonialsHeading = testimonialsSection.getByRole("heading", {
+			name: "Testimonials",
+		});
+		await expect(testimonialsHeading).toBeVisible();
+	});
+
+	test("Testimonials has at least 3 cards", async ({ testimonialsSection }) => {
+		const testimonialsCards = testimonialsSection.locator('[class*="card"]');
+		const count = await testimonialsCards.count();
+		expect(count).toBeGreaterThanOrEqual(3);
+	});
+
+	test("Each card has some feedback, an avatar and a username", async ({
+		testimonialsSection,
+	}) => {
+		const testimonialsCards = testimonialsSection.locator('[class*="card"]');
+		const count = await testimonialsCards.count();
+		for (let i = 0; i < count; i++) {
+			const card = testimonialsCards.nth(i);
+
+			const text = card.locator("p");
+			await expect(text).not.toHaveText("");
+
+			const avatar = card.locator("img");
+			await expect(avatar).toBeVisible();
+			// Optional check for alt names (because these images aren't highlighted):
+			// await expect(avatar).toHaveAttribute('alt', /Roy|Emma|Joan/);
+
+			const userName = card.locator("span");
+			await expect(userName).toBeVisible();
+		}
+	});
+});
+
+test.describe("Footer", async () => {
+	test("Footer has Checkly logo and text", async ({ footer }) => {
+		await expect(footer.getByText("Checkly")).toBeVisible();
+		const footerLogo = footer.locator('img[alt*="Checkly"]');
+		await expect(footerLogo).toBeVisible();
+	});
+
+	test("Footer has legal texts", async ({ footer }) => {
+		await expect(footer.getByText("Terms of Service")).toBeVisible();
+		await expect(footer.getByText("Privacy Policy")).toBeVisible();
+		await expect(footer.getByText("Contact Us")).toBeVisible();
+	});
+
+	test("Footer has 3 visible social media icons", async ({ footer }) => {
+		const socialIcons = footer.locator("svg");
+		const count = await socialIcons.count();
+		expect(count).toBe(3);
+		for (let i = 0; i < count; i++) {
+			await expect(socialIcons.nth(i)).toBeVisible();
+		}
+	});
+
+	//Change for corresponding links once they're added
+	test("Footer elements have corresponding links", async ({ footer }) => {
+		const legalLinks = [
+			{ name: "Terms of Service", href: "/" },
+			{ name: "Privacy Policy", href: "/" },
+			{ name: "Contact Us", href: "/" },
+		];
+
+		for (const { name, href } of legalLinks) {
+			const link = footer.getByRole("link", { name });
+			await expect(link, `${name} should be visible`).toBeVisible();
+			await expect(link, `${name} should have correct href`).toHaveAttribute(
+				"href",
+				href,
+			);
+		}
+
+		const socialLinks = footer.locator('nav[aria-label="Social links"] a');
+		const count = await socialLinks.count();
+
+		for (let i = 0; i < count; i++) {
+			const link = socialLinks.nth(i);
+			await expect(link).toBeVisible(); //This might be redundant
+			await expect(link).toHaveAttribute("href", "/");
+		}
+	});
+});

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"baseUrl": ".",
+		"types": ["@playwright/test", "node"],
+		"paths": {
+			"@schemas/*": ["tests/api/schemas/*"],
+			"@test-helpers-api/*": ["tests/api/helpers/*"],
+			"@test-fixtures-api/*": ["tests/api/fixtures/*"],
+			"@tests/*": ["tests/*"],
+			"@ui/controllers/*": ["tests/ui/controllers/*"],
+			"@ui/*": ["tests/ui/*"]
+		}
+	},
+	"include": ["tests", "playwright.config.ts"],
+	"exclude": ["node_modules"]
+}

--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,20 @@ As we are already using js on both frontend and backend it would be useful to sh
 
 1. [Zod](https://github.com/colinhacks/zod) — a schema validator
 
+### 5.5 Testing Package
+
+#### 5.5.1 Reason
+
+This package (`packages/testing`) contains automated API and UI tests for the Checkly application. It uses [Playwright](https://playwright.dev/) to test both backend and frontend functionality, with environment-based configurations and CI integration.
+
+#### 5.5.2 Technologies
+
+- [Playwright](https://playwright.dev/)
+- [TypeScript](https://www.typescriptlang.org/)
+- [Faker](https://www.npmjs.com/package/@faker-js/faker)
+- [Ajv](https://ajv.js.org/)
+- [dotenv](https://www.npmjs.com/package/dotenv)
+
 ## 6. How to Run
 
 ### 6.1 Manually
@@ -218,3 +232,33 @@ Examples:
 ## 8. Deployment
 
 CI/CD implemented using [GitHub Actions](https://docs.github.com/en/actions)
+
+## 9. Running Tests (packages/testing)
+
+From the **monorepo root**:
+
+1. Ensure dependencies are installed:
+
+```bash
+npm install
+```
+
+> 🛠 This will also automatically install Playwright browsers.
+
+2. Create `.env.local` inside `packages/testing/`:
+
+```env
+FRONTEND_URL=http://localhost:3000/
+API_URL=http://localhost:3001/api/v1/
+```
+
+3. Run tests:
+
+```bash
+npm run testing:test       # Run all tests (local)
+npm run testing:ui         # Run only UI tests
+npm run testing:api        # Run only API tests
+npm run testing:report     # View last HTML report
+```
+
+> The Playwright HTML report will be generated in `packages/testing/playwright-report/index.html`.


### PR DESCRIPTION
## Summary
Integrate the former Playwright automation repo into the monorepo under `packages/testing`.

## What’s included
- New folder `packages/testing` (UI + API tests)
- Config merge: package.json scripts, tsconfig, .gitignore, .env.example
- Playwright config loading envs from `packages/testing`
- Postinstall to install Playwright browsers
- Docs: README for testing package + README main sections (5.4 / 9)

## How to run locally
**1) From repo root:**

```powershell
npm install
``` 

   
**2) Create envs in packages/testing:**
FRONTEND_URL=http://localhost:3000/
API_URL=http://localhost:3001/api/v1/

**3) Run tests:**
```powershell
npm run testing:test      # API + UI
npm run testing:report    # open HTML report
``` 

### Folder structure

packages/testing
├── .env.example / .env.local / .env.production
├── package.json / tsconfig.json / playwright.config.ts
├── tests/
│   ├── api/{auth,controllers,fixtures,helpers,schemas}
│   └── ui/{auth,controllers,fixtures,helpers,landing}
└── playwright-report/ (generated)
