### PR TITLE
fix: remove blank white at the bootom cy-230

### DIFF
--- a/apps/frontend/src/pages/choose-style/style.module.css
+++ b/apps/frontend/src/pages/choose-style/style.module.css
@@ -33,16 +33,13 @@
 	text-decoration: none;
 }
 
-html {
-	zoom: 0.9;
-}
-
 .choose-style-section {
 	--grid-color: var(--color-light-grey);
 	--grid-opacity: 0.4;
 
-	min-height: 111vh;
+	flex: 1;
 	padding-top: 128px;
+	zoom: 0.9;
 }
 
 .bottom-buttons button {
@@ -207,10 +204,6 @@ html {
 		flex: 0 0 auto;
 		margin: 0 auto;
 		scroll-snap-align: center;
-	}
-
-	html {
-		zoom: 1;
 	}
 
 	.choose-style-section {


### PR DESCRIPTION
### Remove blank white at the bootom 

Description: 

On desktop resolutions, the Sign In and Sign Up pages displayed an unnecessary blank white space at the bottom. This was caused by a zoom property applied directly to the html element in choose-style, which altered the page’s scaling and broke the layout.

Solution:

Removed the zoom property from the html selector in choose-style