### PR TITLE
fix: plan overview container minimum height and task control hover contrast cy-231

### DIFF
--- a/apps/frontend/src/libs/components/dashboard-wrapper/styles.module.css
+++ b/apps/frontend/src/libs/components/dashboard-wrapper/styles.module.css
@@ -4,7 +4,7 @@
 
 .main-layout {
 	display: flex;
-	flex: 1;
+	height: 100vh;
 	padding-top: var(--app-header-height);
 	overflow: hidden;
 	transition: all 0.3s ease-in-out;

--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/components/task/styles.module.css
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/components/task/styles.module.css
@@ -84,6 +84,10 @@
 	border-radius: var(--radius-full);
 }
 
+.item-actions_buttons-wrapper button:not(:disabled):hover {
+	background: white;
+}
+
 @media (width <= 1024px) {
 	.item-actions {
 		flex-direction: column;


### PR DESCRIPTION
### Plan Overview bugs

Description:

- The main container no longer fills the full viewport height when the page content is minimal, resulting in empty space below the footer.
- Hovering over task control buttons causes the icons to become invisible due to incorrect background or icon color styling, breaking button visibility.

Solution:

- Updated .main-layout to use min-height: 100vh instead of flex: 1. The previous layout issue was likely caused by the overridden zoom property, which affected element sizing. After removing zoom, using min-height: 100vh ensures the layout fills the full viewport height as expected.
- Adjusted .item-actions_buttons-wrapper hover styles to ensure icons remain visible on hover.


https://github.com/user-attachments/assets/40acf2ba-0d56-4a33-b266-672bbd9e9a21
