### PR TITLE
fix: Checkly logo incorrect font in Landing, Sign-in, and Sign-up pages cy-236

### DIFF
--- a/apps/frontend/src/libs/components/app-header/app-header.tsx
+++ b/apps/frontend/src/libs/components/app-header/app-header.tsx
@@ -1,11 +1,7 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
 
-import {
-	arrowDown,
-	logo,
-	profileDefault,
-} from "~/assets/img/header/header.img.js";
-import { Link } from "~/libs/components/components.js";
+import { arrowDown, profileDefault } from "~/assets/img/header/header.img.js";
+import { Link, Logo } from "~/libs/components/components.js";
 import { AppRoute } from "~/libs/enums/app-route.enum.js";
 import { getClassNames } from "~/libs/helpers/helpers.js";
 import { useAppSelector, useDropdownMenu } from "~/libs/hooks/hooks.js";
@@ -57,9 +53,7 @@ const AppHeader: React.FC = () => {
 	return (
 		<header className={styles["app-header"]}>
 			<div className={styles["logo-section"]}>
-				<Link to="/">
-					<img alt="Checkly logo" className={styles["logo-svg"]} src={logo} />
-				</Link>
+				<Logo />
 			</div>
 
 			<div className={styles["vertical-divider"]} />

--- a/apps/frontend/src/libs/components/app-header/styles.module.css
+++ b/apps/frontend/src/libs/components/app-header/styles.module.css
@@ -41,20 +41,11 @@
 
 .logo-section {
 	z-index: 2;
-	display: flex;
-	gap: 1rem;
-	align-items: center;
-}
-
-.logo-svg {
-	display: block;
-	width: auto;
-	height: 32px;
 	cursor: pointer;
 	transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.logo-svg:hover {
+.logo-section:hover {
 	transform: scale(1.1) rotate(0deg);
 }
 

--- a/apps/frontend/src/libs/components/logo/logo.tsx
+++ b/apps/frontend/src/libs/components/logo/logo.tsx
@@ -13,7 +13,7 @@ const Logo: React.FC = () => {
 			to={AppRoute.ROOT}
 		>
 			<img alt="Binary Checkly web-application logo" src={logoIcon} />
-			Checkly
+			<h1>Checkly</h1>
 		</Link>
 	);
 };

--- a/apps/frontend/src/libs/components/logo/styles.module.css
+++ b/apps/frontend/src/libs/components/logo/styles.module.css
@@ -5,10 +5,13 @@
 	--gutter: 0;
 
 	width: max-content;
-	font-size: var(--text-size-heading-3);
 	text-decoration: none;
 }
 
 .container img {
-	width: clamp(15px, 2vw, 25px);
+	width: clamp(18px, 2vw, 27px);
+}
+
+.container h1 {
+	font-size: var(--text-size-heading-3);
 }


### PR DESCRIPTION
Fixed Checkly logo font to match Figma on the landing, sign-in, and sign-up pages. 

Changes:
- added appropriate tag for header text and updated its styles
- updated Logo component usage in AppHeader component

<img width="1893" height="737" alt="image" src="https://github.com/user-attachments/assets/5e27d30f-553b-4dc0-b62d-8aa157e4b988" />