### PR TITLE
fix: Dashboard and My Plan sections stretch to fill the browser cy-232

### DIFF
--- a/apps/frontend/src/libs/components/dashboard/dashboard.tsx
+++ b/apps/frontend/src/libs/components/dashboard/dashboard.tsx
@@ -7,19 +7,15 @@ import { Greeting } from "./components/greeting/greeting.js";
 import { PastPlans } from "./components/past-plans/past-plans.js";
 import styles from "./styles.module.css";
 
-const classMainContent = getClassNames(
-	"grid-pattern",
-	styles["light-background"],
-	styles["content"],
-);
-
 const Dashboard: FC = () => {
 	return (
-		<div className={classMainContent}>
-			<Greeting />
-			<div className={styles["content-grid"]}>
-				<CurrentPlan />
-				<PastPlans />
+		<div className={getClassNames(styles["dashboard"], "grid-pattern")}>
+			<div className={styles["content"]}>
+				<Greeting />
+				<div className={styles["content-grid"]}>
+					<CurrentPlan />
+					<PastPlans />
+				</div>
 			</div>
 		</div>
 	);

--- a/apps/frontend/src/libs/components/dashboard/styles.module.css
+++ b/apps/frontend/src/libs/components/dashboard/styles.module.css
@@ -1,13 +1,20 @@
-.content {
+.dashboard {
+	display: flex;
+	flex: 1;
+	justify-content: center;
 	height: 100%;
-	padding: var(--space-m);
 	overflow-x: auto;
-	transition: padding 0.3s ease-in-out;
-}
 
-.light-background {
 	--grid-color: var(--color-light-grey);
 	--grid-line: 1px;
+}
+
+.content {
+	width: 100%;
+	max-width: 1300px;
+	height: fit-content;
+	padding: var(--space-m);
+	transition: padding 0.3s ease-in-out;
 }
 
 .content-grid {

--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/components/task/styles.module.css
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/components/task/styles.module.css
@@ -5,7 +5,6 @@
 	align-items: center;
 	justify-content: flex-start;
 	width: 100%;
-	padding: 0;
 	padding: var(--gutter);
 	margin: 0;
 	border: 2px solid black;

--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/components/task/task.tsx
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/components/task/task.tsx
@@ -17,6 +17,7 @@ const Task: React.FC<Properties> = ({ indexItem, item }: Properties) => {
 		<div
 			className={getClassNames(
 				styles["content__tasks-item"],
+				"wrapper",
 				styles[`color-${String(indexItem)}`],
 			)}
 			key={indexItem}


### PR DESCRIPTION
Adjusted the Dashboard and My Plan sections to stretch properly.

Result:

<img width="1920" height="603" alt="image" src="https://github.com/user-attachments/assets/14fe5fb2-9076-4609-8015-52a4975274e6" />

<img width="1919" height="650" alt="image" src="https://github.com/user-attachments/assets/ae818ffb-a32e-4c24-8989-b3e5edc26bea" />
