### PR TITLE
fix(frontend): fixed quiz api path cy-254

### DIFF
--- a/packages/shared/src/modules/quiz/libs/enums/quiz-api-path.enum.ts
+++ b/packages/shared/src/modules/quiz/libs/enums/quiz-api-path.enum.ts
@@ -1,5 +1,5 @@
 const QuizApiPath = {
-	ROOT: "/",
+	ROOT: "",
 } as const;
 
 export { QuizApiPath };


### PR DESCRIPTION
Thanks to @watchlar2000 we found a problem with wrong api path in the deployed version of Checkly which resulted in the infinite loading screen. Small fix is introduced in current PR which only changes ROOT path.

Tested locally
1. GET /quiz-questions
<img width="750" height="87" alt="image" src="https://github.com/user-attachments/assets/ce0e264d-79a8-4d70-8dc3-0cc388cc9037" />

2. POST /quiz
<img width="663" height="105" alt="image" src="https://github.com/user-attachments/assets/7f253fa0-f247-451c-8dec-c082533e07b5" />
