### PR TITLE
refactor(frontend): change logout navigation to homepage cy-169

### DIFF
--- a/apps/frontend/src/modules/auth/slices/actions.ts
+++ b/apps/frontend/src/modules/auth/slices/actions.ts
@@ -80,7 +80,7 @@ const logout = createAsyncThunk<null, LogoutThunkArgument, AsyncThunkConfig>(
 
 		dispatch(authSliceActions.resetAuthState());
 
-		await navigate(AppRoute.SIGN_IN);
+		await navigate(AppRoute.ROOT);
 
 		return null;
 	},


### PR DESCRIPTION
According to Bruno, the logout button should take you to the homepage, not back to the login page.