### PR TITLE
fix: change homepage header button cy-267

### DIFF
--- a/apps/frontend/src/pages/home/components/header/header.tsx
+++ b/apps/frontend/src/pages/home/components/header/header.tsx
@@ -17,7 +17,7 @@ const Header: React.FC = () => {
 					</Link>
 					{user ? (
 						<Link asButtonVariant="secondary" to={AppRoute.DASHBOARD}>
-							Profile
+							My Plans
 						</Link>
 					) : (
 						<Link asButtonVariant="secondary" to={AppRoute.SIGN_IN}>

--- a/apps/frontend/src/pages/home/components/header/styles.module.css
+++ b/apps/frontend/src/pages/home/components/header/styles.module.css
@@ -1,5 +1,7 @@
 .header {
 	--repel-wrap: nowrap;
+	--cluster-horizontal-alignment: flex-end;
+	--gutter: var(--space-s);
 
 	position: fixed;
 	z-index: 999;


### PR DESCRIPTION
Update homepage header button text to "My Plans"

<img width="1917" height="873" alt="image" src="https://github.com/user-attachments/assets/68b4703a-525d-4ab7-a499-3a02f97db05d" />

Update button position in header for mobile

<img width="396" height="751" alt="image" src="https://github.com/user-attachments/assets/7118c0cc-5680-4fea-acce-12ab02550a08" />    <img width="397" height="767" alt="image" src="https://github.com/user-attachments/assets/6f85945c-670f-4613-a332-c37d14b64db1" />
