### PR TITLE
feat: remove exact-optional-property-types from ts-config cy-273

### DIFF
--- a/apps/frontend/src/libs/components/button/button.tsx
+++ b/apps/frontend/src/libs/components/button/button.tsx
@@ -4,7 +4,7 @@ import { type ButtonVariant } from "~/libs/types/types.js";
 import styles from "./styles.module.css";
 
 type Properties = {
-	className?: string | undefined;
+	className?: string;
 	disabled?: boolean;
 	icon?: React.ReactNode;
 	iconOnlySize?: "large" | "medium" | "small";

--- a/apps/frontend/src/libs/components/decorative-image/decorative-image.tsx
+++ b/apps/frontend/src/libs/components/decorative-image/decorative-image.tsx
@@ -3,7 +3,7 @@ import { getClassNames } from "~/libs/helpers/get-class-names.js";
 import styles from "./styles.module.css";
 
 type Properties = {
-	className?: string | undefined;
+	className?: string;
 	src: string;
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
 	"compilerOptions": {
 		"strict": true,
 		"noUncheckedIndexedAccess": true,
-		"exactOptionalPropertyTypes": true,
 		"noPropertyAccessFromIndexSignature": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
Hi!

TS Config has been updated to remove `"exactOptionalPropertyTypes": true`. Issue #273.