### PR TITLE
fix(frontend): return dropdown buttons for tablets/phones cy-304

### DIFF
--- a/apps/frontend/src/libs/components/app-header/user-menu.tsx
+++ b/apps/frontend/src/libs/components/app-header/user-menu.tsx
@@ -53,7 +53,7 @@ const UserMenu: React.FC<Properties> = ({ isOpen }) => {
 					buttonText="Log out"
 					buttonType="logout"
 					icon={<FiLogOut />}
-					navigateTo={AppRoute.SIGN_IN}
+					navigateTo={AppRoute.LOGOUT}
 					onClick={handleLogout}
 				/>
 			</ul>

--- a/apps/frontend/src/libs/components/app-header/user-menu.tsx
+++ b/apps/frontend/src/libs/components/app-header/user-menu.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback } from "react";
-import { FiLogOut } from "react-icons/fi";
+import { FiLogOut, FiUser } from "react-icons/fi";
+import { MdDashboard } from "react-icons/md";
 import { useNavigate } from "react-router-dom";
 
+import { Plan } from "~/assets/img/side-panel/side-panel.img.js";
 import { AppRoute } from "~/libs/enums/app-route.enum.js";
 import { getClassNames } from "~/libs/helpers/helpers.js";
 
@@ -27,10 +29,31 @@ const UserMenu: React.FC<Properties> = ({ isOpen }) => {
 		<nav aria-label="User menu" className={menuDropdownClass}>
 			<ul className={styles["menu-dropdown__list"]}>
 				<NavigationItem
+					buttonText="Profile"
+					buttonType="user-menu"
+					className="hide-desktop-up"
+					icon={<FiUser />}
+					navigateTo={AppRoute.PROFILE}
+				/>
+				<NavigationItem
+					buttonText="Dashboard"
+					buttonType="user-menu"
+					className="hide-desktop-up"
+					icon={<MdDashboard />}
+					navigateTo={AppRoute.DASHBOARD}
+				/>
+				<NavigationItem
+					buttonText="My plan"
+					buttonType="user-menu"
+					className="hide-desktop-up"
+					icon={<Plan />}
+					navigateTo={AppRoute.PLAN}
+				/>
+				<NavigationItem
 					buttonText="Log out"
 					buttonType="logout"
 					icon={<FiLogOut />}
-					navigateTo={AppRoute.LOGOUT}
+					navigateTo={AppRoute.SIGN_IN}
 					onClick={handleLogout}
 				/>
 			</ul>


### PR DESCRIPTION
Returned the buttons i deleted, since we don't want to see them only on Desktop version, while we want them to remain on tablets/mobiles. I just added a simple css class that was implemented before. It hides those for desktop version and only makes them appear on tablets/mobiles.

![dropdown_menu](https://github.com/user-attachments/assets/c72176eb-2189-4c89-99e5-c043ae02b667)
