### PR TITLE
fix(frontend): notes page sanitizer cy-15

### DIFF
--- a/apps/frontend/src/pages/quiz/questions/components/notes-page/notes-page.tsx
+++ b/apps/frontend/src/pages/quiz/questions/components/notes-page/notes-page.tsx
@@ -14,6 +14,13 @@ const NotesPage: React.FC = (): React.ReactElement => {
 
 	const handleNotesChange = useCallback(
 		(event: React.ChangeEvent<HTMLTextAreaElement>): void => {
+			dispatch(actions.setNotes(event.target.value));
+		},
+		[dispatch],
+	);
+
+	const handleNotesBlur = useCallback(
+		(event: React.FocusEvent<HTMLTextAreaElement>): void => {
 			dispatch(actions.setNotes(sanitizeTextInput(event.target.value)));
 		},
 		[dispatch],
@@ -33,6 +40,7 @@ const NotesPage: React.FC = (): React.ReactElement => {
 
 				<textarea
 					className={styles["notes-textarea"]}
+					onBlur={handleNotesBlur}
 					onChange={handleNotesChange}
 					placeholder={PlaceholderValues.WRITE_YOUR_NOTES_HERE}
 					value={notes}


### PR DESCRIPTION
One small fix was needed. Notes page didn't allow spaces (blanks) when typing the text. It was implemented before, but I forgot to add it to the notes page too.

![notes](https://github.com/user-attachments/assets/4ce4e885-4ffe-4d70-b17d-e46b03d2da07)
