### PR TITLE
fix: dob allows future dates cy-176

### DIFF
--- a/apps/frontend/src/libs/components/input/input.tsx
+++ b/apps/frontend/src/libs/components/input/input.tsx
@@ -17,6 +17,8 @@ type Properties<T extends FieldValues> = {
 	errors: FieldErrors<T>;
 	isRequired?: boolean;
 	label: string;
+	max?: string;
+	min?: string;
 	name: FieldPath<T>;
 	placeholder?: string;
 	type?: "date" | "email" | "password" | "text";
@@ -27,6 +29,8 @@ const Input = <T extends FieldValues>({
 	errors,
 	isRequired,
 	label,
+	max,
+	min,
 	name,
 	placeholder = "",
 	type = "text",
@@ -47,6 +51,7 @@ const Input = <T extends FieldValues>({
 		styles["input-container"],
 		"cluster",
 	);
+
 	const inputFieldClass = getClassNames(
 		styles["input-field"],
 		hasError && styles["input-field--error"],
@@ -64,6 +69,8 @@ const Input = <T extends FieldValues>({
 					aria-invalid={hasError}
 					className={inputFieldClass}
 					id={inputId}
+					max={max}
+					min={min}
 					name={name}
 					placeholder={placeholder}
 					required={isRequired}

--- a/apps/frontend/src/pages/profile/profile.tsx
+++ b/apps/frontend/src/pages/profile/profile.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from "react";
+import { MAX_AGE, MIN_AGE } from "shared/src/libs/constants/numbers.js";
 
 import {
 	AvatarEdit,
@@ -39,6 +40,21 @@ const Profile: React.FC = () => {
 		() => getDefaultValues(user as UserDto),
 		[user],
 	);
+
+	const dateLimits = useMemo(() => {
+		const today = new Date();
+
+		const minAgeDate = new Date();
+		minAgeDate.setFullYear(today.getFullYear() - MIN_AGE);
+
+		const maxAgeDate = new Date();
+		maxAgeDate.setFullYear(today.getFullYear() - MAX_AGE);
+
+		return {
+			max: formatDateForInput(minAgeDate.toISOString()),
+			min: formatDateForInput(maxAgeDate.toISOString()),
+		};
+	}, []);
 
 	const { control, errors, handleSubmit, isDirty, isSubmitting, reset } =
 		useAppForm<UserUpdateRequestDto>({
@@ -104,6 +120,8 @@ const Profile: React.FC = () => {
 							control={control}
 							errors={errors}
 							label="Date of birth"
+							max={dateLimits.max}
+							min={dateLimits.min}
 							name="dob"
 							type="date"
 						/>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,10 @@
-export { LAST_INDEX, ONE, ZERO } from "./libs/constants/constants.js";
+export {
+	LAST_INDEX,
+	MAX_AGE,
+	MIN_AGE,
+	ONE,
+	ZERO,
+} from "./libs/constants/constants.js";
 export {
 	UPLOAD_MAX_FILE_SIZE_BYTES,
 	UPLOAD_MAX_FILE_SIZE_MB,

--- a/packages/shared/src/libs/constants/constants.ts
+++ b/packages/shared/src/libs/constants/constants.ts
@@ -1,1 +1,1 @@
-export { LAST_INDEX, ONE, ZERO } from "./numbers.js";
+export { LAST_INDEX, MAX_AGE, MIN_AGE, ONE, ZERO } from "./numbers.js";

--- a/packages/shared/src/libs/constants/numbers.ts
+++ b/packages/shared/src/libs/constants/numbers.ts
@@ -1,5 +1,7 @@
 const ZERO = 0;
 const ONE = 1;
 const LAST_INDEX = -1;
+const MIN_AGE = 13;
+const MAX_AGE = 120;
 
-export { LAST_INDEX, ONE, ZERO };
+export { LAST_INDEX, MAX_AGE, MIN_AGE, ONE, ZERO };

--- a/packages/shared/src/modules/users/libs/enums/user-validation-message.enum.ts
+++ b/packages/shared/src/modules/users/libs/enums/user-validation-message.enum.ts
@@ -1,6 +1,7 @@
 import { UserValidationRule } from "./user-validation-rule.enum.js";
 
 const UserValidationMessage = {
+	AGE_INVALID: "Age must be between 13 and 120 years",
 	DATE_INVALID: "Date must be in format YYYY-MM-DD",
 	EMAIL_ALREADY_EXISTS: "Email already in use",
 	EMAIL_INVALID: "Invalid email format",

--- a/packages/shared/src/modules/users/libs/validation-schemas/user-update.validation-schema.ts
+++ b/packages/shared/src/modules/users/libs/validation-schemas/user-update.validation-schema.ts
@@ -1,10 +1,17 @@
 import { z } from "zod";
 
+import { MAX_AGE, MIN_AGE } from "../../../../libs/constants/numbers.js";
 import {
 	UserValidationMessage,
 	UserValidationRegexRule,
 	UserValidationRule,
 } from "../enums/enums.js";
+
+const minAgeDate = new Date();
+minAgeDate.setFullYear(minAgeDate.getFullYear() - MIN_AGE);
+
+const maxAgeDate = new Date();
+maxAgeDate.setFullYear(maxAgeDate.getFullYear() - MAX_AGE);
 
 const userUpdate = z
 	.object({
@@ -17,6 +24,20 @@ const userUpdate = z
 					value === "" || UserValidationRegexRule.DATE_VALID.test(value),
 				{
 					message: UserValidationMessage.DATE_INVALID,
+				},
+			)
+			.refine(
+				(value) => {
+					if (!value) {
+						return true;
+					}
+
+					const inputDate = new Date(value);
+
+					return inputDate <= minAgeDate && inputDate >= maxAgeDate;
+				},
+				{
+					message: UserValidationMessage.AGE_INVALID,
 				},
 			)
 			.nullable()


### PR DESCRIPTION
# User Age Validation

## Description

This PR adds validation rules for the Date of Birth (DOB), ensuring that users can only register an age between **13 and 120 years**.

### Main Changes

* **Backend Validation**

  * File: `packages/shared/src/modules/users/libs/validation-schemas/user-update.validation-schema.ts`
  * Added validation to the `userUpdate` schema to guarantee that the DOB corresponds to a minimum age of 13 years and a maximum age of 120 years.

* **Frontend Validation (UX)**

  * Updated the `Input` component to accept optional `min` and `max` properties.
  * Applied these limits to the profile form:

    * `min` → date corresponding to 120 years ago.
    * `max` → date corresponding to 13 years ago.

### Motivation

* **Intentional redundancy**: validation was implemented in both frontend and backend.

  * **Frontend** → improves user experience by preventing invalid date selection directly in the datepicker.
  * **Backend** → ensures data integrity, even if the interface is bypassed.

### Benefits

* Greater consistency in data entry.
* Prevents UX issues (users cannot select invalid dates in the calendar).
* Reinforces security and reliability by validating also on the backend.


