### PR TITLE
fix: repeated styles in sample layouts cy-342

### DIFF
--- a/apps/frontend/src/pages/home/components/visual-layouts/libs/constants.ts
+++ b/apps/frontend/src/pages/home/components/visual-layouts/libs/constants.ts
@@ -18,26 +18,6 @@ const layoutExamples: LayoutExample[] = [
 		planStyle: "MINIMAL",
 		title: "Minimal",
 	},
-	{
-		id: 4,
-		planStyle: "WITH_REMARKS",
-		title: "With Remarks",
-	},
-	{
-		id: 5,
-		planStyle: "COLOURFUL",
-		title: "Colourful",
-	},
-	{
-		id: 6,
-		planStyle: "MINIMAL",
-		title: "Minimal",
-	},
-	{
-		id: 7,
-		planStyle: "WITH_REMARKS",
-		title: "With Remarks",
-	},
 ];
 
 export { layoutExamples };


### PR DESCRIPTION
**What was done?**

The constant layoutExamples, which serves as the data source for the section, was updated to contain only unique styles, eliminating the duplicate entries.

**Why was it done?**

This change addresses the issue described in the task 342, where the same three styles were repeated throughout the list, creating a poor visual impression.


For this update, I just removed the duplicate styles.
Removing the slider didn’t seem ideal, since it’s functional and can still be used to accommodate new styles in the future.
