### PR TITLE
fix(frontend): plan overview page buttons width difference cy-352

### DIFF
--- a/apps/frontend/src/libs/components/plan-styles/plan-style/styles.module.css
+++ b/apps/frontend/src/libs/components/plan-styles/plan-style/styles.module.css
@@ -5,7 +5,6 @@
 .container {
 	width: 100%;
 	max-width: calc(595px * var(--coefficient));
-	min-height: calc(842px * var(--coefficient));
 	padding: calc(24px * var(--coefficient));
 }
 
@@ -25,7 +24,7 @@
 
 @media (width <= 768px) {
 	.regular-view {
-		--coefficient: 0.7;
+		--coefficient: 0.8;
 	}
 
 	.container {
@@ -33,9 +32,15 @@
 	}
 }
 
-@media (width <= 475px) {
+@media (width <= 390px) and (height <= 933px) {
 	.regular-view {
-		--coefficient: 0.5;
+		--coefficient: 0.6;
+	}
+}
+
+@media (width <= 480px) {
+	.regular-view {
+		--coefficient: 0.6;
 	}
 }
 

--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/plan.tsx
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/plan.tsx
@@ -100,7 +100,9 @@ const Plan: React.FC = () => {
 
 	if (hasNoPlans) {
 		return (
-			<div className={styles["no-plans-container"]}>
+			<div
+				className={getClassNames(styles["no-plans-container"], "grid-pattern")}
+			>
 				<div className={styles["no-plans-message"]}>No plans yet</div>
 				<Button
 					label="Create Plan"

--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/styles.module.css
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/styles.module.css
@@ -14,7 +14,7 @@
 	height: 100%;
 	padding: var(--gutter);
 	text-align: center;
-	
+
 	--grid-opacity: 0.4;
 }
 

--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/styles.module.css
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/styles.module.css
@@ -14,6 +14,8 @@
 	height: 100%;
 	padding: var(--gutter);
 	text-align: center;
+	
+	--grid-opacity: 0.4;
 }
 
 .no-plans-title {

--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/styles.module.css
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/styles.module.css
@@ -24,7 +24,7 @@
 
 .no-plans-message {
 	margin-bottom: var(--space-l);
-	font-size: var(--text-body);
+	font-size: var(--text-size-heading-4);
 	color: var(--color-text-secondary);
 }
 

--- a/apps/frontend/src/pages/plan-style-overview/components/plan-actions/plan-actions.tsx
+++ b/apps/frontend/src/pages/plan-style-overview/components/plan-actions/plan-actions.tsx
@@ -53,6 +53,7 @@ const PlanActions: React.FC<Properties> = ({
 		<div className={styles["footer-container"]}>
 			<div className={styles["actions-container"]}>
 				<Button
+					className={styles["action-button"]}
 					icon={<Palette aria-hidden="true" />}
 					isDisabled={!isAuthenticated}
 					label="CHOOSE STYLE"
@@ -61,6 +62,7 @@ const PlanActions: React.FC<Properties> = ({
 					variant="secondary"
 				/>
 				<Button
+					className={styles["action-button"]}
 					icon={<EditIcon aria-hidden="true" />}
 					isDisabled={!isAuthenticated}
 					label="EDIT"
@@ -69,6 +71,7 @@ const PlanActions: React.FC<Properties> = ({
 					variant="secondary"
 				/>
 				<Button
+					className={styles["action-button"]}
 					icon={<DownloadIcon aria-hidden="true" />}
 					isDisabled={!isAuthenticated || isDownloading}
 					label="DOWNLOAD"
@@ -82,6 +85,7 @@ const PlanActions: React.FC<Properties> = ({
 					variant="primary"
 				/>
 				<Button
+					className={styles["action-button"]}
 					icon={<Dashboard aria-hidden="true" />}
 					isDisabled={!isAuthenticated}
 					label="GO TO DASHBOARD"

--- a/apps/frontend/src/pages/plan-style-overview/components/plan-actions/styles.module.css
+++ b/apps/frontend/src/pages/plan-style-overview/components/plan-actions/styles.module.css
@@ -13,16 +13,27 @@
 	background: none;
 }
 
+@media (width <= 916px) {
+	.action-button {
+		font-size: 0.6rem;
+	}
+}
+
 @media (width <= 575px) {
 	.footer-container {
-		flex-direction: column-reverse;
+		flex-direction: column;
 		padding-block: 0.75rem;
 	}
 
 	.footer-message {
+		order: -1;
 		margin-top: 0;
 		margin-bottom: 1.2rem;
 		font-weight: 400;
+	}
+
+	.actions-container {
+		order: 1;
 	}
 }
 
@@ -35,8 +46,14 @@
 
 @media (width <= 480px) {
 	.footer-message {
-		margin-top: 0.7rem;
-		font-size: 0.95rem;
+		margin-top: 0.5rem;
+		font-size: 0.8rem;
+	}
+
+	.action-button {
+		max-width: 200px;
+		padding: 0.3rem 0.6rem;
+		font-size: 0.5rem;
 	}
 }
 
@@ -48,55 +65,71 @@
 	padding: 0;
 }
 
-@media (width <= 768px) {
+@media (width <= 845px) and (width > 735px) {
 	.actions-container {
 		gap: var(--space-s);
+		max-height: 200px;
 	}
 
 	.action-button {
-		width: 140px;
-		min-width: 140px;
-		padding: 0.4rem 1.2rem;
+		font-size: 0.5rem;
+	}
+}
+
+@media (width <= 768px) {
+	.actions-container {
+		flex-direction: column;
+		gap: var(--space-s);
+		align-items: center;
+		order: 1;
+	}
+
+	.action-button {
+		justify-content: center;
+		width: 320px;
+		font-size: 0.85rem;
+	}
+
+	.footer-message {
+		order: -1;
+		margin-bottom: 1rem;
+	}
+}
+
+@media (width <= 390px) and (height <= 933px) {
+	.footer-message {
+		margin-top: 0.7rem;
 		font-size: 0.8rem;
 	}
-}
-
-@media (width <= 700px) {
-	.actions-container {
-		flex-direction: column;
-		gap: var(--space-l);
-		align-items: center;
-	}
 
 	.action-button {
-		justify-content: center;
-		width: 100%;
-	}
-}
-
-@media (width <= 480px) {
-	.actions-container {
-		flex-direction: column;
-		gap: var(--space-l);
-		align-items: center;
-	}
-
-	.action-button {
-		justify-content: center;
-		width: 100%;
 		max-width: 200px;
-		padding: 0.6rem 1rem;
+		padding: 0.3rem 0.6rem;
+		font-size: 0.7rem;
 	}
 }
 
-@media (width <= 375px) {
-	.action-button {
-		max-width: 180px;
-		padding: 0.5rem 0.8rem;
-		font-size: 0.75rem;
+@media (width >= 820px) and (height > 1000px) {
+	.footer-container {
+		flex-direction: column;
 	}
 
-	.button-icon {
-		font-size: 0.9rem;
+	.footer-message {
+		order: -1;
+		margin-top: 0;
+		margin-bottom: 1rem;
+	}
+
+	.actions-container {
+		flex-direction: column;
+		gap: var(--space-s);
+		align-items: center;
+		order: 1;
+	}
+
+	.action-button {
+		justify-content: center;
+		width: 300px;
+		font-size: 0.75rem;
 	}
 }

--- a/apps/frontend/src/pages/plan-style-overview/components/plan-style-category/styles.module.css
+++ b/apps/frontend/src/pages/plan-style-overview/components/plan-style-category/styles.module.css
@@ -30,7 +30,7 @@
 	}
 }
 
-@media (width <= 958px) {
+@media (width <= 995px) {
 	.header-buttons {
 		padding: 0.3rem 1rem;
 	}

--- a/apps/frontend/src/pages/plan-style-overview/styles.module.css
+++ b/apps/frontend/src/pages/plan-style-overview/styles.module.css
@@ -115,14 +115,26 @@
 	}
 }
 
+@media (width >= 864px) and (height > 1000px) {
+	.plan-content {
+		margin-bottom: 13rem;
+		transform: scale(1.25);
+		transform-origin: top center;
+	}
+}
+
 @media (width <= 480px) {
 	.header-section {
-		gap: var(--space-l);
+		gap: var(--space-xs);
 		padding: var(--space-xs) var(--space-xs);
 	}
 
 	.plan-content {
-		padding: var(--space-xs) var(--space-xs) 0;
+		padding: var(--space-xs) 0 0;
+	}
+
+	.actions-section {
+		padding: var(--space-xs) var(--space-xs) var(--space-xs);
 	}
 }
 


### PR DESCRIPTION
## Description
Tried to change styles to make buttons the same width for each viewport

## Iphone XR
<img width="505" height="1097" alt="image" src="https://github.com/user-attachments/assets/4f215a1c-2521-4bbb-b021-bcf5e4454b30" />

## Iphone 12 Pro
<img width="505" height="1099" alt="image" src="https://github.com/user-attachments/assets/b7544481-98ff-4957-8d43-10c319ff3921" />

## Samsung Galaxy S20 Ultra
<img width="489" height="1077" alt="image" src="https://github.com/user-attachments/assets/acd81bab-40d3-4af1-ac3b-c5ad547ba4e4" />

## Ipad Air
<img width="731" height="1053" alt="image" src="https://github.com/user-attachments/assets/d585de52-c7a2-4db2-a250-5b0f55ad93f3" />

## Ipad Pro
<img width="761" height="1020" alt="image" src="https://github.com/user-attachments/assets/7cab2c28-3945-47c2-922b-b46d7270ac3c" />

## Additionally fixed
Added grid to "My Plan" page when we have no plans yet

<img width="491" height="933" alt="image" src="https://github.com/user-attachments/assets/cb812c7b-1fa1-4b9d-97ca-dd671a62956e" />

