### PR TITLE
fix: plan not associated to user after succesful authentication cy-349

### DIFF
--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -62,6 +62,7 @@ class AuthController extends BaseController {
 				this.signIn(
 					options as APIHandlerOptions<{
 						body: UserSignInRequestDto;
+						query?: { planId: string };
 					}>,
 				),
 			isPublic: true,
@@ -77,6 +78,7 @@ class AuthController extends BaseController {
 				this.signUp(
 					options as APIHandlerOptions<{
 						body: UserSignUpRequestDto;
+						query?: { planId: string };
 					}>,
 				),
 			isPublic: true,
@@ -330,10 +332,14 @@ class AuthController extends BaseController {
 	private async signIn(
 		options: APIHandlerOptions<{
 			body: UserSignInRequestDto;
+			query?: { planId: string };
 		}>,
 	): Promise<APIHandlerResponse> {
 		return {
-			payload: await this.authService.signIn(options.body),
+			payload: await this.authService.signIn({
+				planId: options.query?.planId,
+				userRequestDto: options.body,
+			}),
 			status: HTTPCode.OK,
 		};
 	}
@@ -380,10 +386,14 @@ class AuthController extends BaseController {
 	private async signUp(
 		options: APIHandlerOptions<{
 			body: UserSignUpRequestDto;
+			query?: { planId: string };
 		}>,
 	): Promise<APIHandlerResponse> {
 		return {
-			payload: await this.authService.signUp(options.body),
+			payload: await this.authService.signUp({
+				planId: options.query?.planId,
+				userRequestDto: options.body,
+			}),
 			status: HTTPCode.CREATED,
 		};
 	}

--- a/apps/backend/src/modules/plans/plans.ts
+++ b/apps/backend/src/modules/plans/plans.ts
@@ -9,7 +9,7 @@ const planRepository = new PlanRepository(PlanModel);
 const planService = new PlanService(planRepository);
 const planController = new PlanController(logger, planService);
 
-export { planController };
+export { planController, planService };
 export {
 	type PlanCreateRequestDto,
 	type PlanDayDto,

--- a/apps/frontend/src/modules/auth/auth-api.ts
+++ b/apps/frontend/src/modules/auth/auth-api.ts
@@ -59,10 +59,13 @@ class AuthApi extends BaseHTTPApi {
 	}
 
 	public async signIn(
+		planId: null | string,
 		payload: UserSignInRequestDto,
 	): Promise<UserSignInResponseDto> {
+		const planIdParameter = planId ? `?planId=${planId}` : "";
+
 		const response = await this.load(
-			this.getFullEndpoint(AuthApiPath.SIGN_IN, {}),
+			this.getFullEndpoint(`${AuthApiPath.SIGN_IN}${planIdParameter}`, {}),
 			{
 				contentType: ContentType.JSON,
 				hasAuth: false,
@@ -75,10 +78,13 @@ class AuthApi extends BaseHTTPApi {
 	}
 
 	public async signUp(
+		planId: null | string,
 		payload: UserSignUpRequestDto,
 	): Promise<UserSignUpResponseDto> {
+		const planIdParameter = planId ? `?planId=${planId}` : "";
+
 		const response = await this.load(
-			this.getFullEndpoint(AuthApiPath.SIGN_UP, {}),
+			this.getFullEndpoint(`${AuthApiPath.SIGN_UP}${planIdParameter}`, {}),
 			{
 				contentType: ContentType.JSON,
 				hasAuth: false,

--- a/apps/frontend/src/modules/auth/slices/actions.ts
+++ b/apps/frontend/src/modules/auth/slices/actions.ts
@@ -29,10 +29,12 @@ const signIn = createAsyncThunk<
 	`${sliceName}/sign-in`,
 	async (registerPayload, { extra, rejectWithValue }) => {
 		const { authApi, storage } = extra;
+		const planId = await storage.get(StorageKey.PLAN_ID);
 
 		try {
-			const { token, user } = await authApi.signIn(registerPayload);
+			const { token, user } = await authApi.signIn(planId, registerPayload);
 			await storage.set(StorageKey.TOKEN, token);
+			await storage.drop(StorageKey.PLAN_ID);
 
 			return user;
 		} catch {
@@ -47,9 +49,11 @@ const signUp = createAsyncThunk<
 	AsyncThunkConfig
 >(`${sliceName}/sign-up`, async (registerPayload, { extra }) => {
 	const { authApi, storage } = extra;
+	const planId = await storage.get(StorageKey.PLAN_ID);
 
-	const { token, user } = await authApi.signUp(registerPayload);
+	const { token, user } = await authApi.signUp(planId, registerPayload);
 	await storage.set(StorageKey.TOKEN, token);
+	await storage.drop(StorageKey.PLAN_ID);
 
 	return user;
 });


### PR DESCRIPTION
Added logic to assign a user to a plan in the db after successful authentication.
- If a plan is generated while the user is not authenticated, the planId is saved in localStorage.
- When the user signs in or signs up, the userId is attached to the plan and the localStorage field is cleared.
- If someone manually changes the value in localStorage and the plan does not exist or belongs to another user, no changes are made and the localStorage field is cleared.