### PR TITLE
fix(frontend): fix blank space, enable button and show new message cy-351

### DIFF
--- a/apps/frontend/src/libs/components/dashboard/components/current-plan/current-plan.tsx
+++ b/apps/frontend/src/libs/components/dashboard/components/current-plan/current-plan.tsx
@@ -1,7 +1,7 @@
 import { type FC, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { Button, Link } from "~/libs/components/components.js";
+import { Button } from "~/libs/components/components.js";
 import { ZERO } from "~/libs/components/dashboard/components/libs/enums/enums.js";
 import { PlanStyle } from "~/libs/components/plan-styles/plan-style/plan-style.js";
 import { AppRoute } from "~/libs/enums/app-route.enum.js";
@@ -56,7 +56,7 @@ const CurrentPlan: FC = () => {
 	if (isLoading) {
 		return (
 			<div className={getClassNames("flow-loose", styles["container"])}>
-				<h2 className={styles["title"]}>Current active plan</h2>
+				<h2 className={styles["title"]}>You have no plans yet</h2>
 				<div className={styles["plan-card"]}>
 					<div>{CURRENT_PLAN_MESSAGES.LOADING}</div>
 				</div>
@@ -67,7 +67,7 @@ const CurrentPlan: FC = () => {
 	if (errorMessage) {
 		return (
 			<div className={getClassNames("flow-loose", styles["container"])}>
-				<h2 className={styles["title"]}>Current active plan</h2>
+				<h2 className={styles["title"]}>You have no plans yet</h2>
 				<div className={styles["plan-card"]}>
 					<div>{errorMessage}</div>
 				</div>
@@ -78,19 +78,7 @@ const CurrentPlan: FC = () => {
 	if (!currentPlan) {
 		return (
 			<div className={getClassNames("flow-loose", styles["container"])}>
-				<h2 className={styles["title"]}>Current active plan</h2>
-				<div className={styles["plan-card"]}>
-					<div>{CURRENT_PLAN_MESSAGES.NO_ACTIVE_PLAN}</div>
-				</div>
-				<div className={styles["button-wrapper"]}>
-					<Link
-						asButtonSize="small"
-						asButtonVariant="primary"
-						to={AppRoute.QUIZ}
-					>
-						Create Plan
-					</Link>
-				</div>
+				<h2 className={styles["title"]}>You have no plans yet</h2>
 			</div>
 		);
 	}

--- a/apps/frontend/src/libs/components/dashboard/components/greeting/greeting.tsx
+++ b/apps/frontend/src/libs/components/dashboard/components/greeting/greeting.tsx
@@ -1,15 +1,20 @@
-import { type FC } from "react";
+import { type FC, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { CreateDoc } from "~/assets/img/icons/icons.js";
+import { AppRoute } from "~/libs/enums/app-route.enum.js";
 import { useAppSelector } from "~/libs/hooks/hooks.js";
 
 import { CreatePlanButton } from "../create-plan-button/create-plan-button.js";
 import styles from "./styles.module.css";
 
-const handleCreatePlan = (): void => {};
-
 const Greeting: FC = () => {
+	const navigate = useNavigate();
 	const user = useAppSelector((state) => state.auth.user);
+
+	const handleCreatePlan = useCallback((): void => {
+		void navigate(AppRoute.QUIZ);
+	}, [navigate]);
 
 	return (
 		<div className={styles["container"]}>
@@ -17,7 +22,6 @@ const Greeting: FC = () => {
 			<CreatePlanButton
 				className={styles["button"] ?? ""}
 				icon={<CreateDoc className={styles["large-icon"]} />}
-				isDisabled
 				label="Create New Plan"
 				onClick={handleCreatePlan}
 			/>

--- a/apps/frontend/src/libs/components/dashboard/components/greeting/styles.module.css
+++ b/apps/frontend/src/libs/components/dashboard/components/greeting/styles.module.css
@@ -24,6 +24,10 @@
 	transition: font-size 0.3s ease-in-out;
 }
 
+.button {
+	gap: 1.2rem;
+}
+
 @media (width >= 768px) {
 	.container {
 		flex-direction: row;
@@ -38,14 +42,12 @@
 
 	.button {
 		flex: 0 1 auto;
-		inline-size: clamp(14rem, 32vw, 22rem);
-		padding-left: calc(var(--space-xl) + 2.5rem);
+		padding-left: calc(var(--space-l) + 2.5rem);
 	}
 
 	.button .large-icon {
 		position: absolute;
 		top: 50%;
-		left: var(--space-m);
 		display: block;
 		pointer-events: none;
 		transform: translateY(-50%) scale(1);
@@ -54,8 +56,6 @@
 
 @media (width >= 1024px) {
 	.button .large-icon {
-		left: var(--space-2xl);
-		left: 10%;
 		transform: translateY(-50%) scale(1.2);
 	}
 }

--- a/apps/frontend/src/libs/components/dashboard/styles.module.css
+++ b/apps/frontend/src/libs/components/dashboard/styles.module.css
@@ -1,5 +1,7 @@
 .dashboard {
 	--grid-color: var(--color-light-grey);
+
+	min-height: 100vh;
 }
 
 .content-grid {


### PR DESCRIPTION
Before Result and Suggestions:

- Blank space left at the bottom of the page
- Remove "Create Plan" and "No active plan found" in the Current active plan section.
- Instead of "Current active plan" it should say "You have no plans yet." when the user has no plans.
- Enable to "Create New Plan" button that is present to the right of the welcome message. It should redirect the user to /quiz and be enabled regardless of plan amount.

Actual Result:
Every point is visible in this video

https://github.com/user-attachments/assets/9b685f4a-3d2b-4304-ae28-c33107d377e6


