### PR TITLE
fix(frontend): persist form input values after failed sign-in and sign-up cy-362

### DIFF
--- a/apps/frontend/src/pages/auth/auth.tsx
+++ b/apps/frontend/src/pages/auth/auth.tsx
@@ -1,3 +1,4 @@
+import { isFulfilled } from "@reduxjs/toolkit";
 import React, { type JSX, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -45,9 +46,11 @@ const Auth: React.FC = () => {
 
 	const handleSignInSubmit = useCallback(
 		(payload: UserSignInRequestDto): void => {
-			void dispatch(authActions.signIn(payload)).then(() => {
-				const redirectPath = handleGetRedirectPath();
-				void navigate(redirectPath ?? AppRoute.DASHBOARD, { replace: true });
+			void dispatch(authActions.signIn(payload)).then((resultAction) => {
+				if (isFulfilled(resultAction)) {
+					const redirectPath = handleGetRedirectPath();
+					void navigate(redirectPath ?? AppRoute.DASHBOARD, { replace: true });
+				}
 			});
 		},
 		[dispatch, navigate, handleGetRedirectPath],
@@ -55,9 +58,11 @@ const Auth: React.FC = () => {
 
 	const handleSignUpSubmit = useCallback(
 		(payload: UserSignUpRequestDto): void => {
-			void dispatch(authActions.signUp(payload)).then(() => {
-				const redirectPath = handleGetRedirectPath();
-				void navigate(redirectPath ?? AppRoute.DASHBOARD, { replace: true });
+			void dispatch(authActions.signUp(payload)).then((resultAction) => {
+				if (isFulfilled(resultAction)) {
+					const redirectPath = handleGetRedirectPath();
+					void navigate(redirectPath ?? AppRoute.DASHBOARD, { replace: true });
+				}
 			});
 		},
 		[dispatch, navigate, handleGetRedirectPath],


### PR DESCRIPTION
Before Result:

- Input fields are cleared after error.
- Sign-Up errors redirect the user to Sign-In, losing all entered registration data.

Actual Result:

- Input values persist after an error is displayed (sing-in and sign-up pages).
- On Sign-Up, users only be redirected upon successful registration.

https://github.com/user-attachments/assets/6cf5c2fb-54f9-42eb-ad72-a4533a07da36

