### PR TITLE
fix: task title overflows when it has many characters long with no spaces cy-358

### DIFF
--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/components/task/styles.module.css
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/components/task/styles.module.css
@@ -96,6 +96,7 @@
 	flex-direction: column;
 	width: 100%;
 	max-width: 100%;
+	word-break: break-all;
 }
 
 .edit-input {
@@ -203,7 +204,7 @@
 	}
 }
 
-@media (width <= 500px) {
+@media (width <= 400px) {
 	.content__tasks-item {
 		flex-wrap: wrap;
 		gap: var(--space-xs);
@@ -218,12 +219,12 @@
 		flex: 1;
 		flex-direction: column;
 		width: 100%;
-		min-width: 100px;
+		min-width: 150px;
 	}
 
 	.edit-input {
 		width: 100%;
-		min-width: 100px;
+		min-width: 150px;
 	}
 
 	.item-actions {


### PR DESCRIPTION
Added word-break for title styles.
Adjusted min-width for smoother responsive behaviour.

<img width="1141" height="728" alt="image" src="https://github.com/user-attachments/assets/c1a9d89a-144d-4174-8025-ff7a972938f3" />