### PR TITLE
feat: add plan export to .ics and confirmation modal on preview cy-294

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -33,6 +33,7 @@
 		"dotenv": "17.2.0",
 		"fastify": "5.4.0",
 		"fastify-plugin": "5.0.1",
+		"ical-generator": "9.0.0",
 		"jose": "6.0.12",
 		"knex": "3.1.0",
 		"objection": "3.1.5",

--- a/apps/backend/src/libs/constants/constants.ts
+++ b/apps/backend/src/libs/constants/constants.ts
@@ -1,1 +1,2 @@
 export { UPLOAD_MAX_FILE_SIZE_BYTES } from "shared";
+export { ONE, ZERO } from "shared";

--- a/apps/backend/src/libs/modules/controller/base-controller.module.ts
+++ b/apps/backend/src/libs/modules/controller/base-controller.module.ts
@@ -47,7 +47,13 @@ class BaseController implements Controller {
 			query: mapped.query,
 			user: request.user,
 		};
-		const { payload, status } = await handler(handlerOptions);
+		const { headers, payload, status } = await handler(handlerOptions);
+
+		if (headers) {
+			for (const [key, value] of Object.entries(headers)) {
+				reply.header(key, value);
+			}
+		}
 
 		return await reply.status(status).send(payload);
 	}

--- a/apps/backend/src/libs/modules/controller/libs/types/api-handler-response.type.ts
+++ b/apps/backend/src/libs/modules/controller/libs/types/api-handler-response.type.ts
@@ -2,6 +2,7 @@ import { type HTTPCode } from "~/libs/modules/http/http.js";
 import { type ValueOf } from "~/libs/types/types.js";
 
 type APIHandlerResponse = {
+	headers?: Record<string, string>;
 	payload: unknown;
 	status: ValueOf<typeof HTTPCode>;
 };

--- a/apps/backend/src/libs/modules/server-application/server-application.ts
+++ b/apps/backend/src/libs/modules/server-application/server-application.ts
@@ -2,6 +2,7 @@ import { config } from "~/libs/modules/config/config.js";
 import { database } from "~/libs/modules/database/database.js";
 import { logger } from "~/libs/modules/logger/logger.js";
 import { authController } from "~/modules/auth/auth.js";
+import { planCalendarExportController } from "~/modules/plan-calendar-export/plan-calendar-export.js";
 import { planCategoryController } from "~/modules/plan-categories/plan-categories.js";
 import { planDayController } from "~/modules/plan-days/plan-days.js";
 import { planPdfExportController } from "~/modules/plan-pdf-export/plan-pdf-export.js";
@@ -21,6 +22,7 @@ const apiV1 = new BaseServerApplicationApi(
 	...planController.routes,
 	...planDayController.routes,
 	...planPdfExportController.routes,
+	...planCalendarExportController.routes,
 	...taskController.routes,
 	...quizQuestionController.routes,
 	...planCategoryController.routes,

--- a/apps/backend/src/modules/plan-calendar-export/libs/enums/enums.ts
+++ b/apps/backend/src/modules/plan-calendar-export/libs/enums/enums.ts
@@ -1,0 +1,1 @@
+export { PlanCalendarExportApiPath } from "shared";

--- a/apps/backend/src/modules/plan-calendar-export/libs/helpers/build-filename.helper.ts
+++ b/apps/backend/src/modules/plan-calendar-export/libs/helpers/build-filename.helper.ts
@@ -1,0 +1,12 @@
+import { type ExportDataDto } from "~/modules/plan-calendar-export/libs/types/types.js";
+
+const buildExportFilename = (
+	date: string,
+	exportData: ExportDataDto,
+): string => {
+	const duration = exportData.days.length;
+
+	return `checkly-plan-${date}-${String(duration)}d.ics`;
+};
+
+export { buildExportFilename };

--- a/apps/backend/src/modules/plan-calendar-export/libs/helpers/create-ics.helper.ts
+++ b/apps/backend/src/modules/plan-calendar-export/libs/helpers/create-ics.helper.ts
@@ -1,0 +1,49 @@
+import ical from "ical-generator";
+
+import { ONE, ZERO } from "~/libs/constants/constants.js";
+import { type ExportDataDto } from "~/modules/plan-calendar-export/libs/types/types.js";
+
+const createCalendarIcs = (
+	exportData: ExportDataDto,
+	planId: number,
+	planTitle: string,
+): string => {
+	const cal = ical({
+		name: planTitle,
+		timezone: "UTC",
+	});
+
+	const startDate = new Date(exportData.startDate);
+
+	for (let dayIndex = 0; dayIndex < exportData.days.length; dayIndex++) {
+		const dayObject = exportData.days[dayIndex];
+
+		if (!dayObject) {
+			continue;
+		}
+
+		const dayStart = new Date(startDate);
+		dayStart.setUTCHours(ZERO, ZERO, ZERO, ZERO);
+		dayStart.setDate(startDate.getDate() + dayIndex);
+
+		const dayEnd = new Date(dayStart);
+		dayEnd.setDate(dayStart.getDate() + ONE);
+
+		let taskIndex = 0;
+
+		for (const task of dayObject.tasks) {
+			cal.createEvent({
+				allDay: true,
+				description: task.notes || undefined,
+				end: dayEnd,
+				start: dayStart,
+				summary: `Day ${String(dayObject.day)} – ${String(taskIndex + ONE)}. ${task.title}`,
+			});
+			taskIndex++;
+		}
+	}
+
+	return cal.toString();
+};
+
+export { createCalendarIcs };

--- a/apps/backend/src/modules/plan-calendar-export/libs/helpers/helpers.ts
+++ b/apps/backend/src/modules/plan-calendar-export/libs/helpers/helpers.ts
@@ -1,0 +1,3 @@
+export { buildExportFilename } from "./build-filename.helper.js";
+export { createCalendarIcs } from "./create-ics.helper.js";
+export { transformPlanToExportData } from "./transform-plan-to-export-data.helper.js";

--- a/apps/backend/src/modules/plan-calendar-export/libs/helpers/transform-plan-to-export-data.helper.ts
+++ b/apps/backend/src/modules/plan-calendar-export/libs/helpers/transform-plan-to-export-data.helper.ts
@@ -1,0 +1,28 @@
+import { type ExportDataDto } from "~/modules/plan-calendar-export/libs/types/types.js";
+import { type PlanDaysTaskDto } from "~/modules/plans/plans.js";
+
+const transformPlanToExportData = (
+	plan: PlanDaysTaskDto,
+	date: string,
+): { exportData: ExportDataDto; planTitle: string } => {
+	const planTitle = plan.title;
+
+	const exportDays = plan.days.map((day) => ({
+		day: day.dayNumber,
+		tasks: day.tasks.map((task) => ({
+			notes: task.description,
+			title: task.title,
+		})),
+	}));
+
+	return {
+		exportData: {
+			days: exportDays,
+			durationDays: plan.duration as ExportDataDto["durationDays"],
+			startDate: date,
+		},
+		planTitle,
+	};
+};
+
+export { transformPlanToExportData };

--- a/apps/backend/src/modules/plan-calendar-export/libs/types/export-ics-headers.type.ts
+++ b/apps/backend/src/modules/plan-calendar-export/libs/types/export-ics-headers.type.ts
@@ -1,0 +1,3 @@
+type ExportIcsHeaders = { [key: string]: string };
+
+export { type ExportIcsHeaders };

--- a/apps/backend/src/modules/plan-calendar-export/libs/types/export-ics-response.type.ts
+++ b/apps/backend/src/modules/plan-calendar-export/libs/types/export-ics-response.type.ts
@@ -1,0 +1,12 @@
+import { type HTTPCode } from "~/libs/modules/http/http.js";
+import { type ValueOf } from "~/libs/types/types.js";
+
+import { type ExportIcsHeaders } from "./export-ics-headers.type.js";
+
+type ExportIcsResponse = {
+	headers: ExportIcsHeaders;
+	payload: string;
+	status: ValueOf<typeof HTTPCode>;
+};
+
+export { type ExportIcsResponse };

--- a/apps/backend/src/modules/plan-calendar-export/libs/types/types.ts
+++ b/apps/backend/src/modules/plan-calendar-export/libs/types/types.ts
@@ -1,0 +1,2 @@
+export { type ExportIcsResponse } from "./export-ics-response.type.js";
+export { type ExportDataDto, type PlanCalendarExportRequestDto } from "shared";

--- a/apps/backend/src/modules/plan-calendar-export/libs/validation-schemas/validation-schemas.ts
+++ b/apps/backend/src/modules/plan-calendar-export/libs/validation-schemas/validation-schemas.ts
@@ -1,0 +1,1 @@
+export { planCalendarExportSchema, planCalendarRequestSchema } from "shared";

--- a/apps/backend/src/modules/plan-calendar-export/plan-calendar-export.controller.ts
+++ b/apps/backend/src/modules/plan-calendar-export/plan-calendar-export.controller.ts
@@ -1,0 +1,57 @@
+import { APIPath, ContentType } from "~/libs/enums/enums.js";
+import {
+	type APIBodyOptions,
+	BaseController,
+} from "~/libs/modules/controller/controller.js";
+import { HTTPCode, HTTPRequestMethod } from "~/libs/modules/http/http.js";
+import { type Logger } from "~/libs/modules/logger/logger.js";
+import { planCalendarRequestSchema } from "~/modules/plan-calendar-export/libs/validation-schemas/validation-schemas.js";
+
+import { PlanCalendarExportApiPath } from "./libs/enums/enums.js";
+import {
+	type ExportIcsResponse,
+	type PlanCalendarExportRequestDto,
+} from "./libs/types/types.js";
+import { type PlanCalendarExportService } from "./plan-calendar-export.service.js";
+
+class PlanCalendarExportController extends BaseController {
+	private planCalendarExportService: PlanCalendarExportService;
+
+	public constructor(
+		logger: Logger,
+		planCalendarExportService: PlanCalendarExportService,
+	) {
+		super(logger, APIPath.PLAN_EXPORT_ROOT);
+		this.planCalendarExportService = planCalendarExportService;
+
+		this.addRoute({
+			handler: (options) =>
+				this.exportCalendar(
+					options as APIBodyOptions<PlanCalendarExportRequestDto>,
+				),
+			method: HTTPRequestMethod.POST,
+			path: PlanCalendarExportApiPath.EXPORT_CALENDAR,
+			validation: {
+				body: planCalendarRequestSchema,
+			},
+		});
+	}
+
+	private async exportCalendar(
+		options: APIBodyOptions<PlanCalendarExportRequestDto>,
+	): Promise<ExportIcsResponse> {
+		const { filename, ics } =
+			await this.planCalendarExportService.generateCalendar(options.body);
+
+		return {
+			headers: {
+				"Content-Disposition": `attachment; filename="${filename}"`,
+				"Content-Type": ContentType.ICS,
+			},
+			payload: ics,
+			status: HTTPCode.OK,
+		};
+	}
+}
+
+export { PlanCalendarExportController };

--- a/apps/backend/src/modules/plan-calendar-export/plan-calendar-export.service.ts
+++ b/apps/backend/src/modules/plan-calendar-export/plan-calendar-export.service.ts
@@ -1,0 +1,55 @@
+import { HTTPCode, HTTPError } from "~/libs/modules/http/http.js";
+import {
+	buildExportFilename,
+	createCalendarIcs,
+	transformPlanToExportData,
+} from "~/modules/plan-calendar-export/libs/helpers/helpers.js";
+import { planCalendarExportSchema } from "~/modules/plan-calendar-export/libs/validation-schemas/validation-schemas.js";
+import { type PlanService } from "~/modules/plans/plan.service.js";
+
+import { type PlanCalendarExportRequestDto } from "./libs/types/types.js";
+
+class PlanCalendarExportService {
+	private planService: PlanService;
+
+	public constructor(planService: PlanService) {
+		this.planService = planService;
+	}
+
+	public async generateCalendar(
+		dto: PlanCalendarExportRequestDto,
+	): Promise<{ filename: string; ics: string }> {
+		const planId = Number(dto.planId);
+		const date = dto.startDate;
+
+		const planEntity = await this.planService.findWithRelations(planId);
+
+		if (!planEntity) {
+			throw new HTTPError({
+				message: "Plan not found",
+				status: HTTPCode.NOT_FOUND,
+			});
+		}
+
+		const { exportData, planTitle } = transformPlanToExportData(
+			planEntity,
+			date,
+		);
+
+		const parseResult = planCalendarExportSchema.safeParse(exportData);
+
+		if (!parseResult.success) {
+			throw new HTTPError({
+				message: "Invalid plan structure for export",
+				status: HTTPCode.UNPROCESSED_ENTITY,
+			});
+		}
+
+		const ics = createCalendarIcs(exportData, planId, planTitle);
+		const filename = buildExportFilename(date, exportData);
+
+		return { filename, ics };
+	}
+}
+
+export { PlanCalendarExportService };

--- a/apps/backend/src/modules/plan-calendar-export/plan-calendar-export.ts
+++ b/apps/backend/src/modules/plan-calendar-export/plan-calendar-export.ts
@@ -1,0 +1,13 @@
+import { logger } from "~/libs/modules/logger/logger.js";
+import { planService } from "~/modules/plans/plans.js";
+
+import { PlanCalendarExportController } from "./plan-calendar-export.controller.js";
+import { PlanCalendarExportService } from "./plan-calendar-export.service.js";
+
+const planCalendarExportService = new PlanCalendarExportService(planService);
+const planCalendarExportController = new PlanCalendarExportController(
+	logger,
+	planCalendarExportService,
+);
+
+export { planCalendarExportController };

--- a/apps/backend/src/modules/plans/plans.ts
+++ b/apps/backend/src/modules/plans/plans.ts
@@ -9,7 +9,7 @@ const planRepository = new PlanRepository(PlanModel);
 const planService = new PlanService(planRepository);
 const planController = new PlanController(logger, planService);
 
-export { planController };
+export { planController, planService };
 export {
 	type PlanCreateRequestDto,
 	type PlanDayDto,

--- a/apps/frontend/src/libs/helpers/date-helpers.ts
+++ b/apps/frontend/src/libs/helpers/date-helpers.ts
@@ -1,3 +1,5 @@
+import { ONE } from "../constants/constants.js";
+
 const formatDateForInput = (dateString: null | string): string => {
 	if (!dateString) {
 		return "";
@@ -8,4 +10,11 @@ const formatDateForInput = (dateString: null | string): string => {
 	return date ?? "";
 };
 
-export { formatDateForInput };
+const addDays = (date: Date, days = ONE): Date => {
+	const result = new Date(date);
+	result.setDate(result.getDate() + days);
+
+	return result;
+};
+
+export { addDays, formatDateForInput };

--- a/apps/frontend/src/libs/modules/store/store.module.ts
+++ b/apps/frontend/src/libs/modules/store/store.module.ts
@@ -9,6 +9,8 @@ import { AppEnvironment } from "~/libs/enums/enums.js";
 import { type Config } from "~/libs/modules/config/config.js";
 import { storage } from "~/libs/modules/storage/storage.js";
 import { authApi, reducer as authReducer } from "~/modules/auth/auth.js";
+import { calendarExportApi } from "~/modules/calendar-export/index.js";
+import { reducer as calendarExportReducer } from "~/modules/calendar-export/slices/calendar-export.js";
 import { pdfExportApi } from "~/modules/pdf-export/pdf-export.js";
 import { reducer as pdfExportReducer } from "~/modules/pdf-export/slices/pdf-export.js";
 import {
@@ -26,6 +28,7 @@ import { listenerMiddleware } from "./listener-middleware/listener-middleware.js
 
 type ExtraArguments = {
 	authApi: typeof authApi;
+	calendarExportApi: typeof calendarExportApi;
 	notifications: typeof notifications;
 	pdfExportApi: typeof pdfExportApi;
 	planApi: typeof planApi;
@@ -38,6 +41,7 @@ type ExtraArguments = {
 
 type RootReducer = {
 	auth: ReturnType<typeof authReducer>;
+	calendarExport: ReturnType<typeof calendarExportReducer>;
 	pdfExport: ReturnType<typeof pdfExportReducer>;
 	plan: ReturnType<typeof planReducer>;
 	planCategory: ReturnType<typeof planCategoryReducer>;
@@ -57,6 +61,7 @@ class Store {
 	public get extraArguments(): ExtraArguments {
 		return {
 			authApi,
+			calendarExportApi,
 			notifications,
 			pdfExportApi,
 			planApi,
@@ -80,6 +85,7 @@ class Store {
 			},
 			reducer: {
 				auth: authReducer,
+				calendarExport: calendarExportReducer,
 				pdfExport: pdfExportReducer,
 				plan: planReducer,
 				planCategory: planCategoryReducer,

--- a/apps/frontend/src/modules/calendar-export/calendar-export-api.ts
+++ b/apps/frontend/src/modules/calendar-export/calendar-export-api.ts
@@ -1,0 +1,46 @@
+import { ONE } from "~/libs/constants/constants.js";
+import { APIPath, ContentType, HTTPRequestMethod } from "~/libs/enums/enums.js";
+import { BaseHTTPApi } from "~/libs/modules/api/api.js";
+import { type HTTP } from "~/libs/modules/http/http.js";
+import { type Storage } from "~/libs/modules/storage/storage.js";
+
+import { PlanCalendarExportApiPath } from "./libs/enums/enums.js";
+import { type PlanCalendarExportRequestDto } from "./libs/types/types.js";
+
+type Constructor = {
+	baseUrl: string;
+	http: HTTP;
+	storage: Storage;
+};
+
+class CalendarExportApi extends BaseHTTPApi {
+	public constructor({ baseUrl, http, storage }: Constructor) {
+		super({ baseUrl, http, path: APIPath.PLAN_EXPORT_ROOT, storage });
+	}
+
+	public async exportCalendar(
+		payload: PlanCalendarExportRequestDto,
+	): Promise<{ blob: Blob; fileName: null | string }> {
+		const fullUrl = this.getFullEndpoint(
+			PlanCalendarExportApiPath.EXPORT_CALENDAR,
+			{},
+		);
+		const response = await this.load(fullUrl, {
+			contentType: ContentType.JSON,
+			hasAuth: true,
+			method: HTTPRequestMethod.POST,
+			payload: JSON.stringify(payload),
+		});
+
+		const contentDisposition = response.headers.get("Content-Disposition");
+		const fileNameRegex = /filename="?([^";]+)"?/i;
+		const fileNameMatch = contentDisposition
+			? fileNameRegex.exec(contentDisposition)
+			: null;
+		const fileName = fileNameMatch?.[ONE] ?? null;
+
+		return { blob: await response.blob(), fileName };
+	}
+}
+
+export { CalendarExportApi };

--- a/apps/frontend/src/modules/calendar-export/calendar-export.instance.ts
+++ b/apps/frontend/src/modules/calendar-export/calendar-export.instance.ts
@@ -1,0 +1,13 @@
+import { config } from "~/libs/modules/config/config.js";
+import { http } from "~/libs/modules/http/http.js";
+import { storage } from "~/libs/modules/storage/storage.js";
+
+import { CalendarExportApi } from "./calendar-export-api.js";
+
+const calendarExportApi = new CalendarExportApi({
+	baseUrl: config.ENV.API.ORIGIN_URL,
+	http,
+	storage,
+});
+
+export { calendarExportApi };

--- a/apps/frontend/src/modules/calendar-export/index.ts
+++ b/apps/frontend/src/modules/calendar-export/index.ts
@@ -1,0 +1,1 @@
+export { calendarExportApi } from "./calendar-export.instance.js";

--- a/apps/frontend/src/modules/calendar-export/libs/enums/enums.ts
+++ b/apps/frontend/src/modules/calendar-export/libs/enums/enums.ts
@@ -1,0 +1,1 @@
+export { PlanCalendarExportApiPath } from "shared";

--- a/apps/frontend/src/modules/calendar-export/libs/types/types.ts
+++ b/apps/frontend/src/modules/calendar-export/libs/types/types.ts
@@ -1,0 +1,1 @@
+export { type PlanCalendarExportRequestDto } from "shared";

--- a/apps/frontend/src/modules/calendar-export/slices.ts
+++ b/apps/frontend/src/modules/calendar-export/slices.ts
@@ -1,0 +1,30 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { type PlanCalendarExportRequestDto } from "shared";
+
+import { MESSAGES } from "~/libs/constants/constants.js";
+import { notifications } from "~/libs/modules/notifications/notifications.js";
+import { type AsyncThunkConfig } from "~/libs/types/types.js";
+import { downloadFile } from "~/pages/plan-style-overview/lib/utils/download-file.utility.js";
+
+const exportCalendar = createAsyncThunk<
+	{ fileName: string },
+	PlanCalendarExportRequestDto,
+	AsyncThunkConfig
+>("calendar-export/export", async (payload, { extra }) => {
+	const { calendarExportApi } = extra;
+
+	try {
+		const { blob, fileName: headerFileName } =
+			await calendarExportApi.exportCalendar(payload);
+		const fileName = headerFileName ?? "plan.ics";
+		downloadFile(blob, fileName);
+
+		return { fileName };
+	} catch {
+		notifications.error(MESSAGES.DOWNLOAD.FAILED);
+
+		return { fileName: "" };
+	}
+});
+
+export { exportCalendar };

--- a/apps/frontend/src/modules/calendar-export/slices/calendar-export.slice.ts
+++ b/apps/frontend/src/modules/calendar-export/slices/calendar-export.slice.ts
@@ -1,0 +1,31 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+import { exportCalendar } from "../slices.js";
+
+type State = {
+	isDownloading: boolean;
+};
+
+const initialState: State = {
+	isDownloading: false,
+};
+
+const { actions, reducer } = createSlice({
+	extraReducers: (builder) => {
+		builder
+			.addCase(exportCalendar.pending, (state) => {
+				state.isDownloading = true;
+			})
+			.addCase(exportCalendar.rejected, (state) => {
+				state.isDownloading = false;
+			})
+			.addCase(exportCalendar.fulfilled, (state) => {
+				state.isDownloading = false;
+			});
+	},
+	initialState,
+	name: "calendarExport",
+	reducers: {},
+});
+
+export { actions, reducer };

--- a/apps/frontend/src/modules/calendar-export/slices/calendar-export.ts
+++ b/apps/frontend/src/modules/calendar-export/slices/calendar-export.ts
@@ -1,0 +1,10 @@
+import { exportCalendar } from "../slices.js";
+import { actions } from "./calendar-export.slice.js";
+
+const allActions = {
+	...actions,
+	exportCalendar,
+};
+
+export { allActions as actions };
+export { reducer } from "./calendar-export.slice.js";

--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/plan.tsx
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/plan.tsx
@@ -108,16 +108,18 @@ const Plan: React.FC = () => {
 						return <Task indexItem={index + ONE} item={item} key={index} />;
 					})}
 					{plan && (
-						<NavLink className={navLink} to={AppRoute.OVERVIEW_PAGE}>
-							<Button
-								icon={<DecorativeImage src={Download} />}
-								iconOnlySize="medium"
-								label="Download PDF"
-								size={ButtonSizes.LARGE}
-								type={ElementTypes.BUTTON}
-								variant={ButtonVariants.PRIMARY}
-							/>
-						</NavLink>
+						<div className={styles["content__download"]}>
+							<NavLink className={navLink} to={AppRoute.OVERVIEW_PAGE}>
+								<Button
+									icon={<DecorativeImage src={Download} />}
+									iconOnlySize="medium"
+									label="Download PDF"
+									size={ButtonSizes.LARGE}
+									type={ElementTypes.BUTTON}
+									variant={ButtonVariants.PRIMARY}
+								/>
+							</NavLink>
+						</div>
 					)}
 				</div>
 			</div>

--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/styles.module.css
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/styles.module.css
@@ -79,6 +79,11 @@
 	margin-top: auto;
 }
 
+.content__download {
+	display: flex;
+	gap: var(--space-2xl);
+}
+
 @media (width <= 768px) {
 	.select-day {
 		display: block;

--- a/apps/frontend/src/pages/plan-style-overview/components/plan-style-category/plan-style-category.tsx
+++ b/apps/frontend/src/pages/plan-style-overview/components/plan-style-category/plan-style-category.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+import { LuCalendarArrowDown } from "react-icons/lu";
 
 import {
 	type CategoryId,
@@ -11,13 +12,19 @@ import { getClassNames } from "~/libs/helpers/helpers.js";
 import styles from "./styles.module.css";
 
 type Properties = {
+	actionButtonDisabled?: boolean;
+	actionButtonLabel?: string;
 	categories: CategoryId[];
+	onActionButtonClick?: () => void;
 	onCategorySelect?: (categoryId: CategoryId) => void;
 	selectedCategory: CategoryId;
 };
 
 const PlanStyleCategory: React.FC<Properties> = ({
+	actionButtonDisabled,
+	actionButtonLabel,
 	categories,
+	onActionButtonClick,
 	onCategorySelect,
 	selectedCategory,
 }) => {
@@ -55,6 +62,29 @@ const PlanStyleCategory: React.FC<Properties> = ({
 					</button>
 				);
 			})}
+
+			{actionButtonLabel ? (
+				<button
+					aria-label={actionButtonLabel}
+					className={getClassNames(
+						styles["category-button"],
+						styles["download-button"],
+					)}
+					disabled={Boolean(actionButtonDisabled)}
+					onClick={onActionButtonClick}
+					type="button"
+				>
+					<span className={styles["category-icon"]}>
+						<LuCalendarArrowDown aria-hidden="true" />
+					</span>
+					<span className={styles["category-name-full"]}>
+						{actionButtonLabel}
+					</span>
+					<span className={styles["category-name-short"]}>
+						{actionButtonLabel}
+					</span>
+				</button>
+			) : null}
 		</div>
 	);
 };

--- a/apps/frontend/src/pages/plan-style-overview/components/plan-style-category/styles.module.css
+++ b/apps/frontend/src/pages/plan-style-overview/components/plan-style-category/styles.module.css
@@ -1,3 +1,4 @@
+/* stylelint-disable order/properties-order */
 .category-container {
 	position: relative;
 	display: flex;
@@ -59,12 +60,29 @@
 	transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+.download-button {
+	text-transform: uppercase;
+	color: rgb(0 0 0 / 100%);
+	background: rgb(198 231 249 / 80%);
+	border: 3px solid rgb(0 0 0 / 80%);
+	border-radius: 1.8rem;
+	font-weight: var(--font-weight-bold);
+	opacity: 1;
+	transform: scale(0.96);
+}
+
 .category-button:hover {
 	color: rgb(0 0 0 / 60%);
 	background: rgb(198 231 249 / 40%);
 	border-color: rgb(0 0 0 / 40%);
 	opacity: 0.9;
 	transform: scale(0.98) translateY(-2px);
+}
+
+.download-button:hover {
+	color: rgb(0 0 0 / 100%);
+	background: rgb(198 231 249 / 80%);
+	border: 3px solid rgb(0 0 0 / 80%);
 }
 
 .category-button.active {

--- a/apps/frontend/src/pages/plan-style-overview/styles.module.css
+++ b/apps/frontend/src/pages/plan-style-overview/styles.module.css
@@ -99,6 +99,14 @@
 	opacity: 0.8;
 }
 
+.calendar-modal {
+	display: flex;
+	flex-direction: row;
+	gap: var(--space-s);
+	justify-content: flex-end;
+	margin-top: var(--space-m);
+}
+
 @media (width <= 768px) {
 	.header-section {
 		position: relative;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -49,6 +49,13 @@ export {
 	generatePlanValidationSchema,
 } from "./modules/openai/openai.js";
 export {
+	type ExportDataDto,
+	PlanCalendarExportApiPath,
+	type PlanCalendarExportRequestDto,
+	planCalendarExportSchema,
+	planCalendarRequestSchema,
+} from "./modules/plan-calendar-export/plan-calendar-export.js";
+export {
 	PlanCategoriesApiPath,
 	type PlanCategoryDto,
 	type PlanCategoryWithColorDto,

--- a/packages/shared/src/libs/enums/content-type.enum.ts
+++ b/packages/shared/src/libs/enums/content-type.enum.ts
@@ -1,4 +1,5 @@
 const ContentType = {
+	ICS: "text/calendar",
 	JSON: "application/json",
 	PDF: "application/pdf",
 } as const;

--- a/packages/shared/src/modules/plan-calendar-export/libs/enums/enums.ts
+++ b/packages/shared/src/modules/plan-calendar-export/libs/enums/enums.ts
@@ -1,0 +1,1 @@
+export { PlanCalendarExportApiPath } from "./plan-calendar-export-api-path.enum.js";

--- a/packages/shared/src/modules/plan-calendar-export/libs/enums/plan-calendar-export-api-path.enum.ts
+++ b/packages/shared/src/modules/plan-calendar-export/libs/enums/plan-calendar-export-api-path.enum.ts
@@ -1,0 +1,5 @@
+const PlanCalendarExportApiPath = {
+	EXPORT_CALENDAR: "/calendar",
+} as const;
+
+export { PlanCalendarExportApiPath };

--- a/packages/shared/src/modules/plan-calendar-export/libs/enums/plan-calendar-export-const.enum.ts
+++ b/packages/shared/src/modules/plan-calendar-export/libs/enums/plan-calendar-export-const.enum.ts
@@ -1,0 +1,6 @@
+const PlanCalendarExportConst = {
+	NOTE_LENGTH: 500,
+	TASKS_IN_DAY: 5,
+} as const;
+
+export { PlanCalendarExportConst };

--- a/packages/shared/src/modules/plan-calendar-export/libs/enums/plan-calendar-export-message.enum.ts
+++ b/packages/shared/src/modules/plan-calendar-export/libs/enums/plan-calendar-export-message.enum.ts
@@ -1,0 +1,15 @@
+import { PlanCalendarExportConst } from "./plan-calendar-export-const.enum.js";
+
+const PlanCalendarExportMessage = {
+	DAY_DUPLICATED: "Day {day} is duplicated.",
+	DAY_INVALID: "Day must be between 1 and {duration}.",
+	DAYS_LENGTH_INVALID: `Each day must have exactly ${String(PlanCalendarExportConst.TASKS_IN_DAY)} tasks.`,
+	DAYS_UNIQUE_INVALID:
+		"Days must contain exactly {duration} items with unique day numbers 1..{duration}.",
+	PLAN_ID_REQUIRED: "Plan ID is required.",
+	START_DATE_INVALID: "Start date must be a valid date in YYYY-MM-DD format.",
+	START_DATE_INVALID_FORMAT: "Start date must be in format YYYY-MM-DD.",
+	TASK_TITLE_REQUIRED: "Task title cannot be empty.",
+} as const;
+
+export { PlanCalendarExportMessage };

--- a/packages/shared/src/modules/plan-calendar-export/libs/enums/plan-calendar-export-regex-rule.enum.ts
+++ b/packages/shared/src/modules/plan-calendar-export/libs/enums/plan-calendar-export-regex-rule.enum.ts
@@ -1,0 +1,5 @@
+const PlanCalendarExportRegexRule = {
+	DATE_VALID: /^\d{4}-\d{2}-\d{2}$/,
+} as const;
+
+export { PlanCalendarExportRegexRule };

--- a/packages/shared/src/modules/plan-calendar-export/libs/helpers/data-helper.ts
+++ b/packages/shared/src/modules/plan-calendar-export/libs/helpers/data-helper.ts
@@ -1,0 +1,5 @@
+const getUtcMidnightDate = (dateString: string): Date => {
+	return new Date(`${dateString}T00:00:00Z`);
+};
+
+export { getUtcMidnightDate };

--- a/packages/shared/src/modules/plan-calendar-export/libs/types/export-plan-calendar-request-dto.type.ts
+++ b/packages/shared/src/modules/plan-calendar-export/libs/types/export-plan-calendar-request-dto.type.ts
@@ -1,0 +1,6 @@
+type PlanCalendarExportRequestDto = {
+	planId: string;
+	startDate: string;
+};
+
+export { type PlanCalendarExportRequestDto };

--- a/packages/shared/src/modules/plan-calendar-export/libs/types/index.ts
+++ b/packages/shared/src/modules/plan-calendar-export/libs/types/index.ts
@@ -1,0 +1,1 @@
+export { type PlanCalendarExportRequestDto } from "./types.js";

--- a/packages/shared/src/modules/plan-calendar-export/libs/types/plan-duration-days.type.ts
+++ b/packages/shared/src/modules/plan-calendar-export/libs/types/plan-duration-days.type.ts
@@ -1,0 +1,7 @@
+const PlanDurationDaysEnum = {
+	FIVE: 5,
+	FOURTEEN: 14,
+	TWENTY_ONE: 21,
+} as const;
+
+export { PlanDurationDaysEnum };

--- a/packages/shared/src/modules/plan-calendar-export/libs/types/types.ts
+++ b/packages/shared/src/modules/plan-calendar-export/libs/types/types.ts
@@ -1,0 +1,1 @@
+export { type PlanCalendarExportRequestDto } from "./export-plan-calendar-request-dto.type.js";

--- a/packages/shared/src/modules/plan-calendar-export/libs/validation-schemas/plan-calendar-export-request.validation-schema.ts
+++ b/packages/shared/src/modules/plan-calendar-export/libs/validation-schemas/plan-calendar-export-request.validation-schema.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+import { ONE } from "../../../../libs/constants/numbers.js";
+import { PlanCalendarExportMessage } from "../enums/plan-calendar-export-message.enum.js";
+import { PlanCalendarExportRegexRule } from "../enums/plan-calendar-export-regex-rule.enum.js";
+import { getUtcMidnightDate } from "../helpers/data-helper.js";
+
+const planCalendarRequestSchema = z.object({
+	planId: z
+		.string()
+		.min(ONE, { message: PlanCalendarExportMessage.PLAN_ID_REQUIRED }),
+	startDate: z
+		.string()
+		.regex(PlanCalendarExportRegexRule.DATE_VALID, {
+			message: PlanCalendarExportMessage.START_DATE_INVALID_FORMAT,
+		})
+		.superRefine((date, context) => {
+			const parsedDate = getUtcMidnightDate(date);
+
+			if (Number.isNaN(parsedDate.getTime())) {
+				context.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: PlanCalendarExportMessage.START_DATE_INVALID,
+					path: [],
+				});
+			}
+		}),
+});
+
+export { planCalendarRequestSchema };

--- a/packages/shared/src/modules/plan-calendar-export/libs/validation-schemas/plan-calendar-export.validation-schema.ts
+++ b/packages/shared/src/modules/plan-calendar-export/libs/validation-schemas/plan-calendar-export.validation-schema.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+
+import { ONE } from "../../../../libs/constants/numbers.js";
+import { PlanCalendarExportConst } from "../enums/plan-calendar-export-const.enum.js";
+import { PlanCalendarExportMessage } from "../enums/plan-calendar-export-message.enum.js";
+import { PlanCalendarExportRegexRule } from "../enums/plan-calendar-export-regex-rule.enum.js";
+import { getUtcMidnightDate } from "../helpers/data-helper.js";
+import { PlanDurationDaysEnum } from "../types/plan-duration-days.type.js";
+
+const taskSchema = z.object({
+	notes: z
+		.string()
+		.trim()
+		.max(PlanCalendarExportConst.NOTE_LENGTH)
+		.optional()
+		.or(z.literal("").transform(() => {})),
+	title: z
+		.string()
+		.trim()
+		.min(ONE, { message: PlanCalendarExportMessage.TASK_TITLE_REQUIRED }),
+});
+
+const daySchema = z.object({
+	day: z.number().int().positive(),
+	tasks: z.array(taskSchema).length(PlanCalendarExportConst.TASKS_IN_DAY, {
+		message: PlanCalendarExportMessage.DAYS_LENGTH_INVALID,
+	}),
+});
+
+const planCalendarExportSchema = z
+	.object({
+		days: z.array(daySchema),
+		durationDays: z.union([
+			z.literal(PlanDurationDaysEnum.FIVE),
+			z.literal(PlanDurationDaysEnum.FOURTEEN),
+			z.literal(PlanDurationDaysEnum.TWENTY_ONE),
+		]),
+		startDate: z.string().regex(PlanCalendarExportRegexRule.DATE_VALID, {
+			message: PlanCalendarExportMessage.START_DATE_INVALID,
+		}),
+	})
+	.superRefine((data, context) => {
+		const duration = data.durationDays;
+
+		if (data.days.length !== duration) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: PlanCalendarExportMessage.DAYS_UNIQUE_INVALID.replace(
+					"{duration}",
+					String(duration),
+				),
+				path: ["days"],
+			});
+		}
+
+		const seen = new Set<number>();
+
+		for (const [index, d] of data.days.entries()) {
+			if (d.day < ONE || d.day > duration) {
+				context.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: PlanCalendarExportMessage.DAY_INVALID.replace(
+						"{duration}",
+						String(duration),
+					),
+					path: ["days", index, "day"],
+				});
+			}
+
+			if (seen.has(d.day)) {
+				context.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: PlanCalendarExportMessage.DAY_DUPLICATED.replace(
+						"{day}",
+						String(d.day),
+					),
+					path: ["days", index, "day"],
+				});
+			}
+
+			seen.add(d.day);
+		}
+
+		const date = getUtcMidnightDate(data.startDate);
+
+		if (Number.isNaN(date.getTime())) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: PlanCalendarExportMessage.START_DATE_INVALID,
+				path: ["startDate"],
+			});
+		}
+	});
+
+type ExportDataDto = z.infer<typeof planCalendarExportSchema>;
+
+export { type ExportDataDto, planCalendarExportSchema };

--- a/packages/shared/src/modules/plan-calendar-export/plan-calendar-export.ts
+++ b/packages/shared/src/modules/plan-calendar-export/plan-calendar-export.ts
@@ -1,0 +1,7 @@
+export { PlanCalendarExportApiPath } from "./libs/enums/enums.js";
+export { type PlanCalendarExportRequestDto } from "./libs/types/index.js";
+export { planCalendarRequestSchema } from "./libs/validation-schemas/plan-calendar-export-request.validation-schema.js";
+export {
+	type ExportDataDto,
+	planCalendarExportSchema,
+} from "./libs/validation-schemas/plan-calendar-export.validation-schema.js";


### PR DESCRIPTION
Added a button for exporting the plan as an ICS file. The current plan is retrieved from the store.
<img width="1331" height="781" alt="image" src="https://github.com/user-attachments/assets/4b903cbf-928f-4b03-b5d6-47f3ece1cfba" />
QA team’s requirements:
 - The “Download Calendar File” button should be on the Plan Preview page, because some users won’t use the My Plan Overview page, and the option needs to be visible to everyone — in the top bar next to Desktop Wallpaper.
 - The name we agreed on for the button is “Download Calendar File.”
 - Please add a modal so that when the button is clicked it says something like:
 “An .ICS file will be downloaded to your computer. You can use this file to import your Checkly plan into the main electronic calendars (Google Calendar, Apple iCalendar, and Outlook).”