### PR TITLE
fix(backend): dob field doesn't accept nullish values cy-363

### DIFF
--- a/apps/backend/src/modules/users/helpers/user-validation.helper.ts
+++ b/apps/backend/src/modules/users/helpers/user-validation.helper.ts
@@ -5,7 +5,11 @@ import { type UserRepository } from "~/modules/users/user.repository.js";
 import { UserValidationMessage } from "../libs/enums/enums.js";
 import { type UserUpdateRequestDto } from "../libs/types/types.js";
 
-const normalizeField = (value?: string): null | string | undefined => {
+const normalizeField = (value?: null | string): null | string | undefined => {
+	if (value === null) {
+		return null;
+	}
+
 	const trimmed = value?.trim();
 
 	return trimmed === "" ? null : trimmed;
@@ -80,7 +84,7 @@ const validateAndPrepareUpdateData = async ({
 	let updateData: UserUpdateData = {};
 
 	if (payload.dob !== undefined) {
-		updateData.dob = payload.dob;
+		updateData.dob = normalizeField(payload.dob);
 	}
 
 	if (email) {


### PR DESCRIPTION
The problem was because logic operator OR was replaced with nullish coalescing operator which didn't accept falsy values.
I decided to adjust the normalizeField function, so that it accepts not only strings, but null values too. And we can apply it to the dob field. So now it works like this:

```
payload.dob = null -> normalizeField(null) -> updateData.dob = null
payload.dob = undefined -> it doesn't enter the scope of that block so we don't update that field at all
payload.dob = "" -> normalizeField("") -> updateData.dob = null
payload.dob = "2025-08-26" -> normalizeField("2025-08-26") -> updateData.dob = "2025-08-26"
```

<img width="1132" height="1138" alt="image" src="https://github.com/user-attachments/assets/6e3b772a-b75f-4457-aa36-171e44367b52" />
