### PR TITLE
fix: password reset endpoint requiring current password + duplicate success toasts cy-371

### DIFF
--- a/apps/backend/src/libs/modules/email-service/libs/constants/email-options-values.ts
+++ b/apps/backend/src/libs/modules/email-service/libs/constants/email-options-values.ts
@@ -1,7 +1,7 @@
 import { type EmailOptions } from "../types/types.js";
 
 const EmailOptionsValues: Readonly<Partial<EmailOptions>> = {
-	from: "Checkly <onboarding@resend.dev>",
+	from: "Checkly <checkly@brunoazvd.com>",
 	subject: "Password Recovery",
 } as const;
 

--- a/apps/backend/src/modules/users/helpers/user-validation.helper.ts
+++ b/apps/backend/src/modules/users/helpers/user-validation.helper.ts
@@ -35,7 +35,6 @@ const validateAndPrepareUpdateData = async ({
 }: ValidateAndPrepareUpdateDataParameters): Promise<UserUpdateData> => {
 	const email = normalizeField(payload.email);
 	const password = normalizeField(payload.password);
-	const currentPassword = normalizeField(payload.currentPassword);
 	const name = normalizeField(payload.name);
 
 	if (email) {
@@ -49,36 +48,13 @@ const validateAndPrepareUpdateData = async ({
 		}
 	}
 
-	if (password) {
-		if (!currentPassword) {
-			throw new HTTPError({
-				message: UserValidationMessage.CURRENT_PASSWORD_REQUIRED,
-				status: HTTPCode.BAD_REQUEST,
-			});
-		}
+	const currentUser = await userRepository.find(id);
 
-		const currentUser = await userRepository.find(id);
-
-		if (!currentUser) {
-			throw new HTTPError({
-				message: UserValidationMessage.USER_NOT_FOUND,
-				status: HTTPCode.NOT_FOUND,
-			});
-		}
-
-		const { passwordHash, passwordSalt } = currentUser.getPasswordData();
-		const isCurrentPasswordValid = await encryptor.compare(
-			currentPassword,
-			passwordHash,
-			passwordSalt,
-		);
-
-		if (!isCurrentPasswordValid) {
-			throw new HTTPError({
-				message: UserValidationMessage.CURRENT_PASSWORD_INVALID,
-				status: HTTPCode.UNPROCESSED_ENTITY,
-			});
-		}
+	if (!currentUser) {
+		throw new HTTPError({
+			message: UserValidationMessage.USER_NOT_FOUND,
+			status: HTTPCode.NOT_FOUND,
+		});
 	}
 
 	let updateData: UserUpdateData = {};

--- a/apps/frontend/src/libs/modules/store/listener-middleware/listener-middleware.ts
+++ b/apps/frontend/src/libs/modules/store/listener-middleware/listener-middleware.ts
@@ -76,23 +76,4 @@ listenerMiddleware.startListening({
 	matcher: isFulfilled(authActions.resetPassword),
 });
 
-listenerMiddleware.startListening({
-	effect: async () => {
-		notifications.success(SuccessMessage.EMAIL_SENT);
-		await navigation.navigateTo(AppRoute.SIGN_IN);
-	},
-	matcher: isAnyOf(
-		authActions.sendResetLink.fulfilled,
-		authActions.sendResetLink.rejected,
-	),
-});
-
-listenerMiddleware.startListening({
-	effect: async () => {
-		notifications.success(SuccessMessage.PASSWORD_CHANGED);
-		await navigation.navigateTo(AppRoute.SIGN_IN);
-	},
-	matcher: isFulfilled(authActions.resetPassword),
-});
-
 export { listenerMiddleware };


### PR DESCRIPTION
- Removed duplicate code in listenerMiddleware.
- Removed validation for current password — now it updates the password correctly.
- Updated the from address for sent emails.

<img width="1024" height="859" alt="image" src="https://github.com/user-attachments/assets/d4eb7fe2-a8c3-48b9-838d-e7d7d4bcbe01" />

<img width="1120" height="282" alt="image" src="https://github.com/user-attachments/assets/a7caf22e-757c-4907-bcc9-cfde314995de" />

<img width="1063" height="867" alt="image" src="https://github.com/user-attachments/assets/c8ea8493-a56b-41d7-bef7-f81e1ea2d5f4" />
