### PR TITLE
fix: forgot/reset password endpoints – security and validation issues cy-385

### DIFF
--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -18,6 +18,7 @@ import {
 
 import { type AuthService } from "./auth.service.js";
 import { AuthApiPath } from "./libs/enums/enums.js";
+import { forgotPasswordValidationSchema } from "./libs/types/types.js";
 
 /**
  * @swagger
@@ -105,6 +106,9 @@ class AuthController extends BaseController {
 			isPublic: true,
 			method: HTTPRequestMethod.POST,
 			path: AuthApiPath.FORGOT_PASSWORD,
+			validation: {
+				body: forgotPasswordValidationSchema,
+			},
 		});
 
 		this.addRoute({

--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -8,7 +8,9 @@ import { HTTPCode, HTTPRequestMethod } from "~/libs/modules/http/http.js";
 import { type Logger } from "~/libs/modules/logger/logger.js";
 import {
 	type ForgotPasswordRequestDto,
+	forgotPasswordValidationSchema,
 	type ResetPasswordRequestDto,
+	resetPasswordWithTokenValidationSchema,
 	type UserSignInRequestDto,
 	userSignInValidationSchema,
 	type UserSignUpRequestDto,
@@ -18,7 +20,6 @@ import {
 
 import { type AuthService } from "./auth.service.js";
 import { AuthApiPath } from "./libs/enums/enums.js";
-import { forgotPasswordValidationSchema } from "./libs/types/types.js";
 
 /**
  * @swagger
@@ -133,6 +134,9 @@ class AuthController extends BaseController {
 			isPublic: true,
 			method: HTTPRequestMethod.POST,
 			path: AuthApiPath.RESET_PASSWORD,
+			validation: {
+				body: resetPasswordWithTokenValidationSchema,
+			},
 		});
 	}
 

--- a/apps/backend/src/modules/auth/auth.service.ts
+++ b/apps/backend/src/modules/auth/auth.service.ts
@@ -56,13 +56,18 @@ class AuthService {
 
 	public async resetPassword({
 		password,
+		token,
 		userId,
 	}: ResetPasswordRequestDto): Promise<void> {
 		const user = await this.userService.find(userId);
 
+		await this.verifyToken({ token, userId });
+
 		if (user) {
 			const { email, name } = user;
 			await this.userService.update(userId, { email, name, password }, true);
+
+			await this.passwordTokenService.deleteByUserId(userId);
 		}
 	}
 

--- a/apps/backend/src/modules/auth/libs/types/types.ts
+++ b/apps/backend/src/modules/auth/libs/types/types.ts
@@ -1,1 +1,0 @@
-export { forgotPasswordValidationSchema } from "shared";

--- a/apps/backend/src/modules/auth/libs/types/types.ts
+++ b/apps/backend/src/modules/auth/libs/types/types.ts
@@ -1,0 +1,1 @@
+export { forgotPasswordValidationSchema } from "shared";

--- a/apps/backend/src/modules/password-token/password-token.repository.ts
+++ b/apps/backend/src/modules/password-token/password-token.repository.ts
@@ -37,6 +37,15 @@ class PasswordTokenRepository implements Repository {
 		return Boolean(deletedPasswordToken);
 	}
 
+	public async deleteByUserId(userId: number): Promise<boolean> {
+		const deletedPasswordToken = await this.passwordTokenModel
+			.query()
+			.where("userId", userId)
+			.delete();
+
+		return Boolean(deletedPasswordToken);
+	}
+
 	public async find(id: number): Promise<null | PasswordTokenEntity> {
 		const passwordToken = await this.passwordTokenModel.query().findById(id);
 

--- a/apps/backend/src/modules/password-token/password-token.service.ts
+++ b/apps/backend/src/modules/password-token/password-token.service.ts
@@ -76,6 +76,10 @@ class PasswordTokenService implements Service {
 		return await this.passwordTokenRepository.delete(id);
 	}
 
+	public async deleteByUserId(userId: number): Promise<boolean> {
+		return await this.passwordTokenRepository.deleteByUserId(userId);
+	}
+
 	public async find(id: number): Promise<null | PasswordTokenDto> {
 		const item = await this.passwordTokenRepository.find(id);
 

--- a/apps/backend/src/modules/users/libs/validation-schemas/validation-schemas.ts
+++ b/apps/backend/src/modules/users/libs/validation-schemas/validation-schemas.ts
@@ -1,3 +1,5 @@
 export { userSignInValidationSchema } from "shared";
 export { userSignUpValidationSchema } from "shared";
 export { userUpdateValidationSchema } from "shared";
+export { forgotPasswordValidationSchema } from "shared";
+export { resetPasswordWithTokenValidationSchema } from "shared";

--- a/apps/backend/src/modules/users/users.ts
+++ b/apps/backend/src/modules/users/users.ts
@@ -19,3 +19,5 @@ export { type ResetPasswordRequestDto } from "./libs/types/types.js";
 export { userSignInValidationSchema } from "./libs/validation-schemas/validation-schemas.js";
 export { userSignUpValidationSchema } from "./libs/validation-schemas/validation-schemas.js";
 export { userUpdateValidationSchema } from "./libs/validation-schemas/validation-schemas.js";
+export { forgotPasswordValidationSchema } from "./libs/validation-schemas/validation-schemas.js";
+export { resetPasswordWithTokenValidationSchema } from "./libs/validation-schemas/validation-schemas.js";

--- a/apps/frontend/src/modules/auth/slices/actions.ts
+++ b/apps/frontend/src/modules/auth/slices/actions.ts
@@ -95,9 +95,9 @@ const resetPassword = createAsyncThunk<
 	AsyncThunkConfig
 >(
 	`${sliceName}/reset-password`,
-	async ({ password, userId }, { rejectWithValue }) => {
+	async ({ password, token, userId }, { rejectWithValue }) => {
 		try {
-			await authApi.resetPassword({ password, userId });
+			await authApi.resetPassword({ password, token, userId });
 		} catch (error) {
 			const errorMessage =
 				error instanceof HTTPError

--- a/apps/frontend/src/pages/auth/components/reset-password/libs/constants/default-reset-password-values.ts
+++ b/apps/frontend/src/pages/auth/components/reset-password/libs/constants/default-reset-password-values.ts
@@ -2,6 +2,7 @@ import { type ResetPasswordRequestDto } from "~/modules/users/users.js";
 
 const DEFAULT_RESET_PASSWORD_VALUES: ResetPasswordRequestDto = {
 	password: "",
+	token: "",
 	userId: -1,
 };
 

--- a/apps/frontend/src/pages/auth/components/reset-password/reset-password.tsx
+++ b/apps/frontend/src/pages/auth/components/reset-password/reset-password.tsx
@@ -59,12 +59,13 @@ const ResetPassword: React.FC<Properties> = ({
 			void handleSubmit((formData) => {
 				const payload: ResetPasswordRequestDto = {
 					...formData,
+					token,
 					userId,
 				};
 				onSubmit(payload);
 			})(event_);
 		},
-		[handleSubmit, onSubmit, userId],
+		[handleSubmit, onSubmit, userId, token],
 	);
 
 	if (isPreparing) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -181,6 +181,7 @@ export {
 	type ResetPasswordFormValidationSchema,
 	type ResetPasswordRequestDto,
 	resetPasswordValidationSchema,
+	resetPasswordWithTokenValidationSchema,
 	S3BucketIndex,
 	type SignUpFormValidationSchema,
 	type UserDto,

--- a/packages/shared/src/modules/users/libs/enums/user-validation-message.enum.ts
+++ b/packages/shared/src/modules/users/libs/enums/user-validation-message.enum.ts
@@ -9,6 +9,7 @@ const UserValidationMessage = {
 		"Date of birth cannot be in the future",
 	EMAIL_ALREADY_EXISTS: "Email already in use",
 	EMAIL_INVALID: "Invalid email format",
+	EMAIL_INVALID_TYPE: "This field requires a string value",
 	ENTER_VALID_DATE_OF_BIRTH: "Please enter a valid date of birth",
 	FAILED_TO_UPDATE_PROFILE: "Failed to update user profile",
 	FIELD_REQUIRED: "Field is required",

--- a/packages/shared/src/modules/users/libs/types/reset-password-request-dto.type.ts
+++ b/packages/shared/src/modules/users/libs/types/reset-password-request-dto.type.ts
@@ -1,5 +1,6 @@
 type ResetPasswordRequestDto = {
 	password: string;
+	token: string;
 	userId: number;
 };
 

--- a/packages/shared/src/modules/users/libs/validation-schemas/forgot-password.validation-schema.ts
+++ b/packages/shared/src/modules/users/libs/validation-schemas/forgot-password.validation-schema.ts
@@ -13,7 +13,9 @@ type ForgotPasswordRequestValidationDto = {
 const forgotPassword = z
 	.object<ForgotPasswordRequestValidationDto>({
 		email: z
-			.string()
+			.string({
+				invalid_type_error: UserValidationMessage.EMAIL_INVALID_TYPE,
+			})
 			.trim()
 			.min(UserValidationRule.NON_EMPTY_STRING_MIN_LENGTH, {
 				message: UserValidationMessage.FIELD_REQUIRED,

--- a/packages/shared/src/modules/users/libs/validation-schemas/reset-password-with-token.validation-schema.ts
+++ b/packages/shared/src/modules/users/libs/validation-schemas/reset-password-with-token.validation-schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+import {
+	UserValidationMessage,
+	UserValidationRegexRule,
+	UserValidationRule,
+} from "../enums/enums.js";
+
+const resetPasswordWithToken = z.object({
+	password: z
+		.string()
+		.min(UserValidationRule.NON_EMPTY_STRING_MIN_LENGTH, {
+			message: UserValidationMessage.FIELD_REQUIRED,
+		})
+		.regex(UserValidationRegexRule.PASSWORD_VALID_CHARS_MIN_MAX, {
+			message: UserValidationMessage.PASSWORD_INVALID,
+		}),
+	token: z.string().min(UserValidationRule.NON_EMPTY_STRING_MIN_LENGTH, {
+		message: UserValidationMessage.FIELD_REQUIRED,
+	}),
+	userId: z.number().int().positive(),
+});
+
+export { resetPasswordWithToken };

--- a/packages/shared/src/modules/users/libs/validation-schemas/validation-schemas.ts
+++ b/packages/shared/src/modules/users/libs/validation-schemas/validation-schemas.ts
@@ -1,4 +1,5 @@
 export { forgotPassword } from "./forgot-password.validation-schema.js";
+export { resetPasswordWithToken } from "./reset-password-with-token.validation-schema.js";
 export {
 	resetPassword,
 	type ResetPasswordFormValidationSchema,

--- a/packages/shared/src/modules/users/users.ts
+++ b/packages/shared/src/modules/users/users.ts
@@ -21,6 +21,7 @@ export {
 	forgotPassword as forgotPasswordValidationSchema,
 	type ResetPasswordFormValidationSchema,
 	resetPassword as resetPasswordValidationSchema,
+	resetPasswordWithToken as resetPasswordWithTokenValidationSchema,
 	type SignUpFormValidationSchema,
 	userSignIn as userSignInValidationSchema,
 	userSignUp as userSignUpValidationSchema,


### PR DESCRIPTION
Updated /auth/forgot-password logic:
- If user provides an incorrect email type (not a string), return 422 with message "This field requires a string value".

Updated  /auth/reset-password logic:
- Added validation for the backend payload.
- Included token in the payload.

Additional:
- Added deletion of password reset token in db once the reset link has been successfully used.