### PR TITLE
fix(frontend): fix layout button and blank space at the bottom cy-398

### DIFF
--- a/apps/frontend/src/libs/components/dashboard/components/greeting/styles.module.css
+++ b/apps/frontend/src/libs/components/dashboard/components/greeting/styles.module.css
@@ -41,7 +41,7 @@
 	}
 
 	.button {
-		flex: 0 1 auto;
+		flex-shrink: 0;
 		padding-left: calc(var(--space-l) + 2.5rem);
 	}
 

--- a/apps/frontend/src/libs/components/dashboard/styles.module.css
+++ b/apps/frontend/src/libs/components/dashboard/styles.module.css
@@ -1,6 +1,8 @@
 .dashboard {
 	--grid-color: var(--color-light-grey);
 	--grid-opacity: var(--dashboard-grid-opacity);
+
+	min-height: 100%;
 }
 
 .content-grid {


### PR DESCRIPTION
Before Result:

- Icon inside the button overlaps with the button text.
- The wrapper does not cover the whole screen, leaving an empty gap at the bottom of the page.

Actual Result:

- "Create New Plan" button height and spacing remain consistent regardless of greeting length.
- Icon and text remain properly aligned.
- The wrapper cover the whole screen without leaving gaps or creating unecessary scrolling.


https://github.com/user-attachments/assets/9b4b1a06-f8b2-4298-a9f7-4566a7076f51

