### PR TITLE
fix(frontend): fix slider of templates on mobile view cy-404

### DIFF
--- a/apps/frontend/src/pages/home/components/visual-layouts/styles.module.css
+++ b/apps/frontend/src/pages/home/components/visual-layouts/styles.module.css
@@ -88,3 +88,9 @@
 	pointer-events: none;
 	transform: translate(-120%, -170%);
 }
+
+@media (width <= 600px) {
+	.layout-list {
+		justify-content: flex-start;
+	}
+}


### PR DESCRIPTION
Before Result:

- User can't properly see the template. Around half is covered and can't be slided into view.

Actual Result:

https://github.com/user-attachments/assets/09c0e5c7-65a3-446e-ae45-d04cc4f641d9

