### PR TITLE
fix: Remove Format Selector from Choose Style Page cy-421

### DIFF
--- a/apps/frontend/src/pages/choose-style/choose-style.tsx
+++ b/apps/frontend/src/pages/choose-style/choose-style.tsx
@@ -1,13 +1,7 @@
 import React, { useState } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
 
-import {
-	ArrowLeftIcon,
-	DownloadIcon,
-	FileIcon,
-	MonitorIcon,
-	SmartphoneIcon,
-} from "~/assets/img/icons/icons.js";
+import { ArrowLeftIcon, DownloadIcon } from "~/assets/img/icons/icons.js";
 import {
 	FlowerPink,
 	StarsYellow02,
@@ -129,29 +123,6 @@ const ChooseStyle: React.FC = () => {
 						</button>
 					</NavLink>
 					<p className={styles["nav-title"]}>Choose the style</p>
-				</div>
-				<div className={styles["header-buttons"]}>
-					<Button
-						className={styles["header-buttons-button"]}
-						icon={<FileIcon aria-hidden="true" />}
-						label="PDF"
-						size="small"
-					/>
-					<Button
-						className={styles["header-buttons-button"]}
-						icon={<SmartphoneIcon aria-hidden="true" />}
-						iconOnlySize="large"
-						isDisabled
-						label="Mobile Wallpaper"
-						size="small"
-					/>
-					<Button
-						className={styles["header-buttons-button"]}
-						icon={<MonitorIcon aria-hidden="true" />}
-						isDisabled
-						label="Desktop Wallpaper"
-						size="small"
-					/>
 				</div>
 				<div
 					aria-labelledby="card-text"

--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/plan.tsx
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/plan.tsx
@@ -184,7 +184,7 @@ const Plan: React.FC = () => {
 						<Button
 							icon={<DownloadIcon />}
 							iconOnlySize="medium"
-							label="Download PDF"
+							label="Download"
 							size={ButtonSizes.LARGE}
 							type={ElementTypes.BUTTON}
 							variant={ButtonVariants.PRIMARY}


### PR DESCRIPTION

<img width="1413" height="953" alt="image" src="https://github.com/user-attachments/assets/88b6ab39-6954-4b85-b7df-bb18e120f3e6" />

Little adjustment

<img width="1144" height="592" alt="image" src="https://github.com/user-attachments/assets/a5f4c110-c44b-4dde-85e1-ecde4a650440" />
