### PR TITLE
fix: Dashboard Past Plans Display Incorrect Background Color cy-420

### DIFF
--- a/apps/frontend/src/libs/components/dashboard/components/past-plans/past-plans.tsx
+++ b/apps/frontend/src/libs/components/dashboard/components/past-plans/past-plans.tsx
@@ -114,7 +114,12 @@ const PastPlans: FC = () => {
 			{userPlans.map((plan) => (
 				<div
 					aria-hidden="true"
-					className={styles["plan-card"]}
+					className={getClassNames(
+						styles["plan-card"],
+						styles[
+							`plan-card__bg-${getPlanStyleName(plan.styleId).toLowerCase()}`
+						],
+					)}
 					data-plan-id={plan.id}
 					key={plan.id}
 					onClick={handlePlanSelect}

--- a/apps/frontend/src/libs/components/dashboard/components/past-plans/styles.module.css
+++ b/apps/frontend/src/libs/components/dashboard/components/past-plans/styles.module.css
@@ -42,8 +42,16 @@
 	display: grid;
 	place-content: center;
 	padding: var(--space-s);
-	background-color: var(--color-bg-plan-style-with-remarks);
 	border-radius: var(--radius-m);
+}
+
+.plan-card__bg-with_remarks {
+	background-color: var(--color-bg-plan-style-with-remarks);
+}
+
+.plan-card__bg-colourful,
+.plan-card__bg-minimal {
+	background-color: var(--color-bg-white);
 }
 
 .plan-card:hover {


### PR DESCRIPTION
<img width="523" height="688" alt="image" src="https://github.com/user-attachments/assets/b7942094-7b5f-49b1-85d6-f1a025981675" />
