### PR TITLE
fix: quiz category issues cy-435

### DIFF
--- a/apps/frontend/src/pages/quiz/quiz.tsx
+++ b/apps/frontend/src/pages/quiz/quiz.tsx
@@ -17,6 +17,7 @@ import {
 } from "~/libs/enums/enums.js";
 import { getClassNames } from "~/libs/helpers/get-class-names.js";
 import { useAppDispatch, useAppSelector } from "~/libs/hooks/hooks.js";
+import { storage, StorageKey } from "~/libs/modules/storage/storage.js";
 import {
 	actions as planActions,
 	type PlanCategoryWithColorDto,
@@ -40,11 +41,18 @@ const Quiz: React.FC = (): React.ReactElement => {
 	const { selectedCategory } = useAppSelector((state) => state.quizQuestion);
 
 	const handleCategorySelect = useCallback(
-		(category: string): void => {
-			dispatch(actions.resetQuiz());
-			dispatch(actions.setCategory(category));
+		(clickedCategory: string): void => {
+			if (clickedCategory !== selectedCategory) {
+				const clearStateAndSetCategory = async (): Promise<void> => {
+					await storage.drop(StorageKey.QUIZ_STATE);
+					dispatch(actions.resetQuiz());
+					dispatch(actions.setCategory(clickedCategory));
+				};
+
+				void clearStateAndSetCategory();
+			}
 		},
-		[dispatch],
+		[dispatch, selectedCategory],
 	);
 
 	const handleBack = useCallback((): void => {


### PR DESCRIPTION
Fixed a bug that caused the progress of a previous quiz to be incorrectly loaded when trying to start a new quiz with a different category. 
The solution involved explicitly clearing the saved quiz state from the browser’s storage at the moment a new category is selected.

### Root Cause
The bug occurred because the **“restart quiz”** logic, triggered when selecting a new category, only cleared the temporary application state (managed by Redux), but did not remove the state that was permanently stored in localStorage.

### Implemented Solution
The fix ensures that the saved state is cleared whenever the user selects a new category.
Every time a user picks a category, the application first deletes any trace of a previous quiz from persistent storage and only then starts a completely new session.


![Animação](https://github.com/user-attachments/assets/25f334a9-bb12-4977-aff9-44aee9ae1f3b)

