### PR TITLE
feat: add button to edit page cy-461

### DIFF
--- a/apps/frontend/src/libs/components/plan-task-create-form/plan-task-create-form.tsx
+++ b/apps/frontend/src/libs/components/plan-task-create-form/plan-task-create-form.tsx
@@ -27,15 +27,16 @@ const PlanTaskCreateForm = ({
 	onCancel,
 	onSubmit,
 }: Properties): JSX.Element => {
-	const { control, errors, getValues, handleSubmit, reset, setValue } =
-		useAppForm({
-			defaultValues: {
-				executionTimeType: "morning" as ExecutionTimeTypeValue,
-				title: "",
-			},
-			mode: "onBlur",
-			validationSchema: taskCreatePartialValidationSchema,
-		});
+	const { control, errors, handleSubmit, reset, setValue, watch } = useAppForm({
+		defaultValues: {
+			executionTimeType: "morning" as ExecutionTimeTypeValue,
+			title: "",
+		},
+		mode: "onBlur",
+		validationSchema: taskCreatePartialValidationSchema,
+	});
+
+	const currentExecutionTime = watch("executionTimeType");
 
 	const handleTimeChange = useCallback(
 		(newTime: ExecutionTimeTypeValue) => {
@@ -66,7 +67,7 @@ const PlanTaskCreateForm = ({
 				<div className={getClassNames("flow-tight", styles["time-select"])}>
 					<label htmlFor="time-selector">Select time period:</label>
 					<TaskTimeSelector
-						currentTime={getValues().executionTimeType}
+						currentTime={currentExecutionTime}
 						inputId="time-selector"
 						onTimeChange={handleTimeChange}
 						selectStyles={selectStyles}

--- a/apps/frontend/src/libs/hooks/use-app-form/use-app-form.hook.ts
+++ b/apps/frontend/src/libs/hooks/use-app-form/use-app-form.hook.ts
@@ -35,7 +35,7 @@ type ReturnValue<T extends FieldValues = FieldValues> = {
 	reset: UseFormReset<T>;
 	setError?: UseFormSetError<T>;
 	setValue: UseFormSetValue<T>;
-	watch?: UseFormWatch<T>;
+	watch: UseFormWatch<T>;
 };
 
 const useAppForm = <T extends FieldValues = FieldValues>({

--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/plan.tsx
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/plan.tsx
@@ -207,6 +207,34 @@ const Plan: React.FC = () => {
 						</NavLink>
 					</div>
 				</div>
+				<div
+					className={getClassNames(
+						styles["content__tasks"],
+						"cluster grid-pattern flow-loose",
+					)}
+				>
+					<TaskList
+						daysLoading={daysLoading}
+						onRegenerate={handleTaskRegenerate}
+						selectedDayId={plan?.days[selectedDay]?.id ?? ZERO}
+						tasks={plan?.days[selectedDay]?.tasks ?? []}
+						tasksLoading={tasksLoading}
+					/>
+					<NavLink
+						className={getClassNames(styles["nav-link"])}
+						tabIndex={-1}
+						to={AppRoute.OVERVIEW_PAGE}
+					>
+						<Button
+							icon={<DownloadIcon />}
+							iconOnlySize="medium"
+							label="Download"
+							size={ButtonSizes.LARGE}
+							type={ElementTypes.BUTTON}
+							variant={ButtonVariants.PRIMARY}
+						/>
+					</NavLink>
+				</div>
 			</div>
 			<ConfirmationModal
 				isOpen={isRegeneratePlanModalOpen}

--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/plan.tsx
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/plan.tsx
@@ -207,34 +207,6 @@ const Plan: React.FC = () => {
 						</NavLink>
 					</div>
 				</div>
-				<div
-					className={getClassNames(
-						styles["content__tasks"],
-						"cluster grid-pattern flow-loose",
-					)}
-				>
-					<TaskList
-						daysLoading={daysLoading}
-						onRegenerate={handleTaskRegenerate}
-						selectedDayId={plan?.days[selectedDay]?.id ?? ZERO}
-						tasks={plan?.days[selectedDay]?.tasks ?? []}
-						tasksLoading={tasksLoading}
-					/>
-					<NavLink
-						className={getClassNames(styles["nav-link"])}
-						tabIndex={-1}
-						to={AppRoute.OVERVIEW_PAGE}
-					>
-						<Button
-							icon={<DownloadIcon />}
-							iconOnlySize="medium"
-							label="Download"
-							size={ButtonSizes.LARGE}
-							type={ElementTypes.BUTTON}
-							variant={ButtonVariants.PRIMARY}
-						/>
-					</NavLink>
-				</div>
 			</div>
 			<ConfirmationModal
 				isOpen={isRegeneratePlanModalOpen}

--- a/apps/frontend/src/pages/home/components/feedbacks-section/components/feedback-modals/add-feedback.modal.tsx
+++ b/apps/frontend/src/pages/home/components/feedbacks-section/components/feedback-modals/add-feedback.modal.tsx
@@ -50,7 +50,7 @@ const AddFeedbackModal: React.FC<Properties> = ({
 		}
 	}, [existingFeedback, reset]);
 
-	const textValue = watch?.("text") ?? "";
+	const textValue = watch("text");
 	const characterCount = textValue.length;
 	const maxCharacters = FeedbackValidationRule.TEXT_MAX_LENGTH;
 

--- a/apps/frontend/src/pages/plan-edit/plan-edit.tsx
+++ b/apps/frontend/src/pages/plan-edit/plan-edit.tsx
@@ -542,25 +542,14 @@ const PlanEdit: React.FC = () => {
 							/>
 							<span className="visually-hidden">Back to the previous page</span>
 						</Link>
-						<div className={getClassNames("cluster", styles["nav-left-title"])}>
-							<h2 className={styles["plan-title"]}>{plan.title}</h2>
-							<div className={styles["nav-left-manage-link"]}>
-								<Link
-									asButtonSize="small"
-									asButtonVariant="secondary"
-									to={AppRoute.PLAN}
-								>
-									Manage plan
-								</Link>
-							</div>
-						</div>
-						<Button
-							className={getClassNames(styles["select-day"])}
-							label={`Day ${String(selectedDay + ONE)}`}
-							onClick={toggleSelect}
-							variant={ButtonVariants.TRANSPARENT}
-						/>
+						<h2 className={styles["plan-title"]}>{plan.title}</h2>
 					</div>
+					<Button
+						className={getClassNames(styles["select-day"])}
+						label={`Day ${String(selectedDay + ONE)}`}
+						onClick={toggleSelect}
+						variant={ButtonVariants.TRANSPARENT}
+					/>
 				</div>
 				<div className={styles["content"]}>
 					<div className={styles["content__days-wrapper"]}>

--- a/apps/frontend/src/pages/plan-edit/plan-edit.tsx
+++ b/apps/frontend/src/pages/plan-edit/plan-edit.tsx
@@ -542,14 +542,25 @@ const PlanEdit: React.FC = () => {
 							/>
 							<span className="visually-hidden">Back to the previous page</span>
 						</Link>
-						<h2 className={styles["plan-title"]}>{plan.title}</h2>
+						<div className={getClassNames("cluster", styles["nav-left-title"])}>
+							<h2 className={styles["plan-title"]}>{plan.title}</h2>
+							<div className={styles["nav-left-manage-link"]}>
+								<Link
+									asButtonSize="small"
+									asButtonVariant="secondary"
+									to={AppRoute.PLAN}
+								>
+									Manage plan
+								</Link>
+							</div>
+						</div>
+						<Button
+							className={getClassNames(styles["select-day"])}
+							label={`Day ${String(selectedDay + ONE)}`}
+							onClick={toggleSelect}
+							variant={ButtonVariants.TRANSPARENT}
+						/>
 					</div>
-					<Button
-						className={getClassNames(styles["select-day"])}
-						label={`Day ${String(selectedDay + ONE)}`}
-						onClick={toggleSelect}
-						variant={ButtonVariants.TRANSPARENT}
-					/>
 				</div>
 				<div className={styles["content"]}>
 					<div className={styles["content__days-wrapper"]}>

--- a/apps/frontend/src/pages/plan-edit/plan-edit.tsx
+++ b/apps/frontend/src/pages/plan-edit/plan-edit.tsx
@@ -542,7 +542,12 @@ const PlanEdit: React.FC = () => {
 							/>
 							<span className="visually-hidden">Back to the previous page</span>
 						</Link>
-						<h2 className={styles["plan-title"]}>{plan.title}</h2>
+						<h2 className={styles["plan-title"]}>
+							{plan.title} -{" "}
+							<Link className={styles["plan-title-link"]} to={AppRoute.PLAN}>
+								Manage plan
+							</Link>
+						</h2>
 					</div>
 					<Button
 						className={getClassNames(styles["select-day"])}

--- a/apps/frontend/src/pages/plan-edit/styles.module.css
+++ b/apps/frontend/src/pages/plan-edit/styles.module.css
@@ -7,9 +7,13 @@
 }
 
 .plan-title {
-	max-width: clamp(150px, 50vw, 600px);
+	max-width: clamp(15rem, 50vw, 100%);
 	font-size: var(--text-size-heading-3);
 	text-wrap: balance;
+}
+
+.plan-title-link {
+	color: var(--color-text-secondary);
 }
 
 .nav-left {

--- a/apps/frontend/src/pages/plan-edit/styles.module.css
+++ b/apps/frontend/src/pages/plan-edit/styles.module.css
@@ -13,7 +13,29 @@
 }
 
 .nav-left {
+	--cluster-vertical-alignment: flex-start;
+	--cluster-horizontal-alignment: justify-content;
 	--gutter: var(--space-m);
+
+	width: 100%;
+}
+
+.nav-left-title {
+	--cluster-direction: column;
+}
+
+@media (width >= 768px) {
+	.nav-left-title {
+		--cluster-direction: row;
+		--cluster-vertical-alignment: center;
+		--cluster-horizontal-alignment: justify-content;
+
+		flex: 1;
+	}
+
+	.nav-left-manage-link {
+		margin-left: auto;
+	}
 }
 
 .no-plans-container {
@@ -56,6 +78,7 @@
 .select-day {
 	display: block;
 	padding: var(--space-2xs) var(--space-m);
+	margin-left: auto;
 	font-size: var(--text-body);
 	font-weight: var(--font-weight-body);
 	text-transform: none;

--- a/apps/frontend/src/pages/plan-edit/styles.module.css
+++ b/apps/frontend/src/pages/plan-edit/styles.module.css
@@ -13,29 +13,7 @@
 }
 
 .nav-left {
-	--cluster-vertical-alignment: flex-start;
-	--cluster-horizontal-alignment: justify-content;
 	--gutter: var(--space-m);
-
-	width: 100%;
-}
-
-.nav-left-title {
-	--cluster-direction: column;
-}
-
-@media (width >= 768px) {
-	.nav-left-title {
-		--cluster-direction: row;
-		--cluster-vertical-alignment: center;
-		--cluster-horizontal-alignment: justify-content;
-
-		flex: 1;
-	}
-
-	.nav-left-manage-link {
-		margin-left: auto;
-	}
 }
 
 .no-plans-container {
@@ -78,7 +56,6 @@
 .select-day {
 	display: block;
 	padding: var(--space-2xs) var(--space-m);
-	margin-left: auto;
 	font-size: var(--text-body);
 	font-weight: var(--font-weight-body);
 	text-transform: none;


### PR DESCRIPTION
To support #431: 
- Added "manage plan" button on plan-edit page.
- Fixed "download" link on my-plan page.
- Fixed https://github.com/BinaryStudioAcademy/bsa-2025-checkly/issues/431#issuecomment-3237410015

<img width="1919" height="778" alt="image" src="https://github.com/user-attachments/assets/fe4781a9-a949-44fa-8c26-cf971098724f" />


