### PR TITLE
fix: Past Plan Not Set as Active After Continue cy-468

### DIFF
--- a/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/plan.tsx
+++ b/apps/frontend/src/pages/dashboard-wrapper-mock/components/plan/plan.tsx
@@ -36,8 +36,10 @@ const Plan: React.FC = () => {
 	const planDaysNumber = useAppSelector((state) => state.plan.days);
 
 	useEffect(() => {
-		void dispatch(planActions.getPlan());
-	}, [dispatch]);
+		if (!plan) {
+			void dispatch(planActions.getPlan());
+		}
+	}, [dispatch, plan]);
 
 	const handleDayRegenerate = useCallback(
 		(dayId: number) => {


### PR DESCRIPTION

https://github.com/user-attachments/assets/b0b6d618-ce08-48b5-a090-40255323419e

